### PR TITLE
Bug/geom upsert

### DIFF
--- a/pgdb/handler.go
+++ b/pgdb/handler.go
@@ -9,6 +9,11 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+type simpleResponse struct {
+	Status  int
+	Message string
+}
+
 // UpsertRasModel ...
 func UpsertRasModel(ac *config.APIConfig, db *sqlx.DB) echo.HandlerFunc {
 	return func(c echo.Context) error {
@@ -23,7 +28,7 @@ func UpsertRasModel(ac *config.APIConfig, db *sqlx.DB) echo.HandlerFunc {
 
 		err := upsertModelInfo(definitionFile, ac, db)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, err)
+			return c.JSON(http.StatusInternalServerError, simpleResponse{http.StatusInternalServerError, err.Error()})
 		}
 
 		return c.JSON(http.StatusOK, "Successfully uploaded model information for "+definitionFile)
@@ -44,7 +49,7 @@ func UpsertRasGeometry(ac *config.APIConfig, db *sqlx.DB) echo.HandlerFunc {
 
 		err := upsertModelGeometry(definitionFile, ac, db)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, err)
+			return c.JSON(http.StatusInternalServerError, simpleResponse{http.StatusInternalServerError, err.Error()})
 		}
 
 		return c.JSON(http.StatusOK, "Successfully uploaded model geometry for "+definitionFile)
@@ -58,7 +63,7 @@ func VacuumRasViews(db *sqlx.DB) echo.HandlerFunc {
 		for _, query := range vacuumQuery {
 			_, err := db.Exec(query)
 			if err != nil {
-				return c.JSON(http.StatusInternalServerError, err)
+				return c.JSON(http.StatusInternalServerError, simpleResponse{http.StatusInternalServerError, err.Error()})
 			}
 		}
 
@@ -73,7 +78,7 @@ func RefreshRasViews(db *sqlx.DB) echo.HandlerFunc {
 		for _, query := range refreshViewsQuery {
 			_, err := db.Exec(query)
 			if err != nil {
-				return c.JSON(http.StatusInternalServerError, err)
+				return c.JSON(http.StatusInternalServerError, simpleResponse{http.StatusInternalServerError, err.Error()})
 			}
 		}
 

--- a/pgdb/tools.go
+++ b/pgdb/tools.go
@@ -122,7 +122,7 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 	}
 
 	modelID, err := getModelID(tx, definitionFile)
-	fmt.Println("Model ID:", modelID)
+	fmt.Println("Model ID:", modelID, "Name|", definitionFile)
 	if err != nil {
 		fmt.Println(err)
 		return err

--- a/pgdb/tools.go
+++ b/pgdb/tools.go
@@ -152,7 +152,7 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 				geometryFile.GeomTitle,
 				version,
 				geometryFile.Description); err != nil {
-				fmt.Println("Geometry File|", err)
+				fmt.Println("Geometry File", geometryFile.FileExt, "|", err)
 				tx.Rollback()
 				return err
 			}
@@ -183,7 +183,7 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 				cutLineProfileMatch := xs.Fields["CutLineProfileMatch"]
 				xsStation, err := strconv.ParseFloat(xs.FeatureName, 64)
 				if err != nil {
-					fmt.Println("XS|", err)
+					fmt.Println("XS", geometryFile.FileExt, "|", err)
 					tx.Rollback()
 					return err
 				}
@@ -209,7 +209,7 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 
 				_, err = tx.Exec(upsertBanksSQL, xsID, bankStation, banks.Geometry)
 				if err != nil {
-					fmt.Println("Banks|", err)
+					fmt.Println("Banks", geometryFile.FileExt, "|", err)
 					tx.Rollback()
 					return err
 				}
@@ -219,17 +219,17 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 			for _, storageArea := range features.StorageAreas {
 				_, err = tx.Exec(upsertStorageAreasSQL, geometryFileID, storageArea.FeatureName, storageArea.Geometry)
 				if err != nil {
-					fmt.Println("Storage Areas|", err)
+					fmt.Println("Storage Areas", geometryFile.FileExt, "|", err)
 					tx.Rollback()
 					return err
 				}
 			}
-
-			err = tx.Commit()
-			if err != nil {
-				fmt.Println("Transaction Commit Error|", err)
-				return err
-			}
+		}
+		
+		err = tx.Commit()
+		if err != nil {
+			fmt.Println("Transaction Commit Error|", err)
+			return err
 		}
 
 	}

--- a/tools/flow.go
+++ b/tools/flow.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -34,7 +35,7 @@ func getFlowData(rm *RasModel, fn string, wg *sync.WaitGroup) {
 		meta.Notes += msg
 		rm.Metadata.FlowFiles = append(rm.Metadata.FlowFiles, meta)
 		if err != nil {
-			fmt.Println(err)
+			log.Println(err)
 		}
 	}()
 

--- a/tools/geom.go
+++ b/tools/geom.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -32,7 +33,7 @@ func getGeomData(rm *RasModel, fn string, wg *sync.WaitGroup) {
 		meta.Notes += msg
 		rm.Metadata.GeomFiles = append(rm.Metadata.GeomFiles, meta)
 		if err != nil {
-			fmt.Println(err)
+			log.Println(err)
 		}
 	}()
 
@@ -70,7 +71,7 @@ func getGeomData(rm *RasModel, fn string, wg *sync.WaitGroup) {
 		case strings.HasPrefix(line, "River Reach="):
 			structures, err := getHydraulicStructureData(rm, fn, idx)
 			if err != nil {
-				fmt.Println("Hydraulic Structures|", meta.FileExt, err)
+				log.Println("Hydraulic Structures|", meta.FileExt, err)
 				continue
 			}
 			meta.Structures = append(meta.Structures, structures)

--- a/tools/geom.go
+++ b/tools/geom.go
@@ -70,7 +70,7 @@ func getGeomData(rm *RasModel, fn string, wg *sync.WaitGroup) {
 		case strings.HasPrefix(line, "River Reach="):
 			structures, err := getHydraulicStructureData(rm, fn, idx)
 			if err != nil {
-				fmt.Println(meta.FileExt, err)
+				fmt.Println("Hydraulic Structures|", meta.FileExt, err)
 				continue
 			}
 			meta.Structures = append(meta.Structures, structures)

--- a/tools/geom.go
+++ b/tools/geom.go
@@ -70,7 +70,7 @@ func getGeomData(rm *RasModel, fn string, wg *sync.WaitGroup) {
 		case strings.HasPrefix(line, "River Reach="):
 			structures, err := getHydraulicStructureData(rm, fn, idx)
 			if err != nil {
-				fmt.Println(err)
+				fmt.Println(meta.FileExt, err)
 				continue
 			}
 			meta.Structures = append(meta.Structures, structures)

--- a/tools/geospatial.go
+++ b/tools/geospatial.go
@@ -56,7 +56,6 @@ func checkUnitConsistency(modelUnits string, sourceCRS string) error {
 				return nil
 		}
 	}
-		fmt.Println(modelUnits, crsUnits)
 		return errors.New("The unit system of the model and coordinate reference system are inconsistent")
 	}
 	return errors.New("Unable to check unit consistency, could not identify the coordinate reference system's units")

--- a/tools/geospatial.go
+++ b/tools/geospatial.go
@@ -43,18 +43,20 @@ type xyzPoint struct {
 	z float64
 }
 
-var unitConsistencyMap map[string]string = map[string]string{
-	"English Units": "US survey foot",
-	"SI Units":      "metre"}
+
+var unitConsistencyMap [][]string = [][]string{{"english units", "us survey foot", "foot_us", "foot us", "us foot"}, {"si units","metre", "meter"}}
 
 // checkUnitConsistency checks that the unit system used by the model and its coordinate reference system are the same
 func checkUnitConsistency(modelUnits string, sourceCRS string) error {
 	sourceSpRef := gdal.CreateSpatialReference(sourceCRS)
 
 	if crsUnits, ok := sourceSpRef.AttrValue("UNIT", 0); ok {
-		if unitConsistencyMap[modelUnits] == crsUnits {
-			return nil
+		for _, unitsSet := range unitConsistencyMap {
+			if stringInSlice(strings.ToLower(modelUnits), unitsSet) && stringInSlice(strings.ToLower(crsUnits), unitsSet) {
+				return nil
 		}
+	}
+		fmt.Println(modelUnits, crsUnits)
 		return errors.New("The unit system of the model and coordinate reference system are inconsistent")
 	}
 	return errors.New("Unable to check unit consistency, could not identify the coordinate reference system's units")

--- a/tools/geospatial.go
+++ b/tools/geospatial.go
@@ -70,11 +70,11 @@ out:
 		line := sc.Text()
 		for s := 0; s < colWidth; {
 			if len(line) > s {
-				val1, err := strconv.ParseFloat(strings.TrimSpace(line[s:s+valueWidth]), 64)
+				val1, err := parseFloat(strings.TrimSpace(line[s:s+valueWidth]), 64)
 				if err != nil {
 					return pairs, err
 				}
-				val2, err := strconv.ParseFloat(strings.TrimSpace(line[s+valueWidth:s+stride]), 64)
+				val2, err := parseFloat(strings.TrimSpace(line[s+valueWidth:s+stride]), 64)
 				if err != nil {
 					return pairs, err
 				}
@@ -358,7 +358,7 @@ func getBanks(line string, transform gdal.CoordinateTransform, xsLayer VectorLay
 		layer := VectorLayer{FeatureName: strings.TrimSpace(s), Fields: map[string]interface{}{}}
 		layer.Fields["RiverReachName"] = xsLayer.Fields["RiverReachName"]
 		layer.Fields["xsName"] = xsLayer.FeatureName
-		bankStation, err := strconv.ParseFloat(s, 64)
+		bankStation, err := parseFloat(s, 64)
 		if err != nil {
 			return layers, err
 		}

--- a/tools/geospatial.go
+++ b/tools/geospatial.go
@@ -44,14 +44,14 @@ type xyzPoint struct {
 }
 
 
-var unitConsistencyMap [][]string = [][]string{{"english units", "us survey foot", "foot_us", "foot us", "us foot"}, {"si units","metre", "meter"}}
+var unitConsistencyGroups [][]string = [][]string{{"english units", "us survey foot", "foot_us", "foot us", "us foot"}, {"si units","metre", "meter"}}
 
 // checkUnitConsistency checks that the unit system used by the model and its coordinate reference system are the same
 func checkUnitConsistency(modelUnits string, sourceCRS string) error {
 	sourceSpRef := gdal.CreateSpatialReference(sourceCRS)
 
 	if crsUnits, ok := sourceSpRef.AttrValue("UNIT", 0); ok {
-		for _, unitsSet := range unitConsistencyMap {
+		for _, unitsSet := range unitConsistencyGroups {
 			if stringInSlice(strings.ToLower(modelUnits), unitsSet) && stringInSlice(strings.ToLower(crsUnits), unitsSet) {
 				return nil
 		}

--- a/tools/model.go
+++ b/tools/model.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -198,14 +197,14 @@ func (rm *RasModel) Index() Model {
 // IsGeospatial ...
 func (rm *RasModel) IsGeospatial() bool {
 	if rm.Metadata.Projection == "" {
-		fmt.Println("no valid coordinate reference system")
+		fmt.Println(rm.Metadata.ProjFilePath, "| no valid coordinate reference system")
 		return false
 	}
 	modelVersions := strings.Split(rm.Version, ",")
 	for _, version := range modelVersions {
 		if strings.Contains(version, ".g") {
 			geomVersion := strings.TrimSpace(strings.Split(version, ":")[1])
-			v, err := strconv.ParseFloat(geomVersion, 64)
+			v, err := parseFloat(geomVersion, 64)
 			if err != nil {
 				fmt.Println("could not convert the geometry version to a float")
 				return false
@@ -284,7 +283,7 @@ func getProjection(rm *RasModel, fn string, wg *sync.WaitGroup) {
 
 	sourceSpRef := gdal.CreateSpatialReference(line)
 	if err := sourceSpRef.Validate(); err != nil {
-		fmt.Println(fmt.Sprintf("%s is not a valid projection file.\n", fn))
+		fmt.Println(fmt.Sprintf("%s is not a valid projection file.", fn))
 		return
 	}
 	if rm.Metadata.Projection != "" {

--- a/tools/model.go
+++ b/tools/model.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"log"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -199,7 +198,7 @@ func (rm *RasModel) Index() Model {
 // IsGeospatial ...
 func (rm *RasModel) IsGeospatial() bool {
 	if rm.Metadata.Projection == "" {
-		log.Println("no valid coordinate reference system")
+		fmt.Println("no valid coordinate reference system")
 		return false
 	}
 	modelVersions := strings.Split(rm.Version, ",")
@@ -208,11 +207,11 @@ func (rm *RasModel) IsGeospatial() bool {
 			geomVersion := strings.TrimSpace(strings.Split(version, ":")[1])
 			v, err := strconv.ParseFloat(geomVersion, 64)
 			if err != nil {
-				log.Println("could not convert the geometry version to a float")
+				fmt.Println("could not convert the geometry version to a float")
 				return false
 			}
 			if v < 4 {
-				log.Printf("geometry file version: %f is not geospatial", v)
+				fmt.Printf("geometry file version: %f is not geospatial", v)
 				return false
 			}
 		}

--- a/tools/plan.go
+++ b/tools/plan.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -37,7 +38,7 @@ func getPlanData(rm *RasModel, fn string, wg *sync.WaitGroup) {
 		meta.Notes += msg
 		rm.Metadata.PlanFiles = append(rm.Metadata.PlanFiles, meta)
 		if err != nil {
-			fmt.Println(err)
+			log.Println(err)
 		}
 	}()
 

--- a/tools/structures.go
+++ b/tools/structures.go
@@ -121,7 +121,7 @@ out:
 				if sVal != "" {
 					nvalues++
 					if nvalues%interval == 0 {
-						val, err := strconv.ParseFloat(sVal, 64)
+						val, err := parseFloat(sVal, 64)
 						if err != nil {
 							return values, i, err
 						}
@@ -204,7 +204,7 @@ func getHighLowChord(hsSc *bufio.Scanner, i int, nElevText string, colWidth int,
 func stringtoFloat(s string) (float64, error) {
 	trimmed := strings.TrimSpace(s)
 	if trimmed != "" {
-		val, err := strconv.ParseFloat(trimmed, 64)
+		val, err := parseFloat(trimmed, 64)
 		if err != nil {
 			return 0, err
 		}
@@ -266,7 +266,7 @@ func getConduits(line string, single bool) (conduits, error) {
 func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, int, error) {
 	culvert := culverts{}
 
-	station, err := strconv.ParseFloat(strings.TrimSpace(lineData[1]), 64)
+	station, err := parseFloat(strings.TrimSpace(lineData[1]), 64)
 	if err != nil {
 		return culvert, i, err
 	}
@@ -291,7 +291,7 @@ func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, in
 			i++
 			hsSc.Scan()
 			nextLineData := strings.Split(hsSc.Text(), ",")
-			deckWidth, err := strconv.ParseFloat(strings.TrimSpace(nextLineData[0]), 64)
+			deckWidth, err := parseFloat(strings.TrimSpace(nextLineData[0]), 64)
 			if err != nil {
 				return culvert, i, err
 			}
@@ -342,7 +342,7 @@ func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, in
 func getBridgeData(hsSc *bufio.Scanner, i int, lineData []string) (bridges, int, error) {
 	bridge := bridges{}
 
-	station, err := strconv.ParseFloat(strings.TrimSpace(lineData[1]), 64)
+	station, err := parseFloat(strings.TrimSpace(lineData[1]), 64)
 	if err != nil {
 		return bridge, i, err
 	}
@@ -367,7 +367,7 @@ func getBridgeData(hsSc *bufio.Scanner, i int, lineData []string) (bridges, int,
 			i++
 			hsSc.Scan()
 			nextLineData := strings.Split(hsSc.Text(), ",")
-			deckWidth, err := strconv.ParseFloat(strings.TrimSpace(nextLineData[0]), 64)
+			deckWidth, err := parseFloat(strings.TrimSpace(nextLineData[0]), 64)
 			if err != nil {
 				return bridge, i, err
 			}
@@ -446,7 +446,7 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 		wi++
 		if wi == i {
 			lineData := strings.Split(rightofEquals(wSc.Text()), ",")
-			station, err := strconv.ParseFloat(strings.TrimSpace(lineData[1]), 64)
+			station, err := parseFloat(strings.TrimSpace(lineData[1]), 64)
 			if err != nil {
 				return weir, err
 			}
@@ -480,7 +480,7 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 			case strings.HasPrefix(line, "IW Dist,WD"):
 				wSc.Scan()
 				nextLineData := strings.Split(wSc.Text(), ",")
-				weirWidth, err := strconv.ParseFloat(strings.TrimSpace(nextLineData[1]), 64)
+				weirWidth, err := parseFloat(strings.TrimSpace(nextLineData[1]), 64)
 				if err != nil {
 					return weir, err
 				}

--- a/tools/structures.go
+++ b/tools/structures.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"bufio"
-	"errors"
 	"math"
 	"strconv"
 	"strings"
@@ -330,14 +329,11 @@ func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, in
 			culvert.Conduits = append(culvert.Conduits, conduit)
 			culvert.NumConduits++
 
-		case strings.HasPrefix(line, "BC Design"):
+		case strings.HasPrefix(line, "Type RM Length L Ch R ="):
 			return culvert, i, nil
 
-		case strings.HasPrefix(line, "Type RM Length L Ch R ="):
-			return culvert, i, errors.New("Failed to terminate parsing of culvert at 'BC Design'")
-
 		case strings.HasPrefix(line, "River Reach="):
-			return culvert, i, errors.New("Failed to terminate parsing of culvert at 'BC Design'")
+			return culvert, i, nil
 		}
 	}
 	return culvert, i, nil
@@ -396,14 +392,11 @@ func getBridgeData(hsSc *bufio.Scanner, i int, lineData []string) (bridges, int,
 		case strings.HasPrefix(line, "Pier Skew"):
 			bridge.NumPiers++
 
-		case strings.HasPrefix(line, "BC Design"):
+		case strings.HasPrefix(line, "Type RM Length L Ch R ="):
 			return bridge, i, nil
 
-		case strings.HasPrefix(line, "Type RM Length L Ch R ="):
-			return bridge, i, errors.New("Failed to terminate parsing of bridge at 'BC Design'")
-
 		case strings.HasPrefix(line, "River Reach="):
-			return bridge, i, errors.New("Failed to terminate parsing of bridge at 'BC Design'")
+			return bridge, i, nil
 		}
 	}
 	return bridge, i, nil

--- a/tools/utils.go
+++ b/tools/utils.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"bufio"
 	"errors"
+	"strconv"
 	"strings"
 )
 
@@ -67,4 +68,11 @@ func stringInSlice(val string, s []string) bool {
 		}
 	}
 	return false
+}
+
+func parseFloat(s string, bitSize int) (float64, error) {
+	if s == "" {
+		return 0, nil
+	}
+	return strconv.ParseFloat(s, bitSize)
 }

--- a/tools/utils.go
+++ b/tools/utils.go
@@ -59,3 +59,12 @@ func getDescription(sc *bufio.Scanner, idx int, endLine string) (string, int, er
 	}
 	return description, idx, nil
 }
+
+func stringInSlice(val string, s []string) bool {
+	for i := range s {
+		if s[i] == val {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Fix miscellaneous bugs:

- Returning empty {} for internal server error
- Termination at `BC Design`
- SQL transaction for each geom file rather than at the end
- Unit consistency check not accounting for all possible scenarios
- Errors printed as normal print statements
- Float parsing failing for empty string

closes # https://github.com/Dewberry/fni-dms/issues/114 https://github.com/Dewberry/fni-dms/issues/112

There are more errors as well but they will be fixed after improving logs and error handling since it is taking much longer to debug without proper logs and stack trace. 