### PR TITLE
Return Error Stack Trace #patch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,10 @@ require (
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/swaggo/swag v1.7.0
+	github.com/go-errors/errors v1.4.1
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6 // indirect
+
 )

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/dewberry/gdal v0.3.1/go.mod h1:3knazvb7vQFrFAl7+iWI34xP0iiRS7iRFZ1C4J
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-errors/errors v1.4.1 h1:IvVlgbzSsaUNudsw5dcXSzF3EWyXTi5XrAdngnuhRyg=
+github.com/go-errors/errors v1.4.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=

--- a/handlers/geospatialdata.go
+++ b/handlers/geospatialdata.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"app/config"
@@ -31,12 +32,12 @@ func GeospatialData(ac *config.APIConfig) echo.HandlerFunc {
 
 		rm, err := ras.NewRasModel(definitionFile, *ac.FileStore)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error(), err.(*errors.Error).ErrorStack()})
+			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, fmt.Sprintf("Go error encountered: %v", err.Error()), err.(*errors.Error).ErrorStack()})
 		}
 
 		data, err := rm.GeospatialData(ac.DestinationCRS)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error(), err.(*errors.Error).ErrorStack()})
+			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, fmt.Sprintf("Go error encountered: %v", err.Error()), err.(*errors.Error).ErrorStack()})
 		}
 
 		return c.JSON(http.StatusOK, data)

--- a/handlers/geospatialdata.go
+++ b/handlers/geospatialdata.go
@@ -7,6 +7,7 @@ import (
 
 	ras "app/tools"
 
+	"github.com/go-errors/errors" // warning: replaces standard errors
 	"github.com/labstack/echo/v4"
 )
 
@@ -30,12 +31,12 @@ func GeospatialData(ac *config.APIConfig) echo.HandlerFunc {
 
 		rm, err := ras.NewRasModel(definitionFile, *ac.FileStore)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error()})
+			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error(), err.(*errors.Error).ErrorStack()})
 		}
 
 		data, err := rm.GeospatialData(ac.DestinationCRS)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error()})
+			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error(), err.(*errors.Error).ErrorStack()})
 		}
 
 		return c.JSON(http.StatusOK, data)

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -6,6 +6,7 @@ import (
 	ras "app/tools"
 
 	"github.com/USACE/filestore"
+	"github.com/go-errors/errors" // warning: replaces standard errors
 	"github.com/labstack/echo/v4"
 )
 
@@ -29,7 +30,7 @@ func Index(fs *filestore.FileStore) echo.HandlerFunc {
 
 		rm, err := ras.NewRasModel(definitionFile, *fs)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error()})
+			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error(), err.(*errors.Error).ErrorStack()})
 		}
 		mod := rm.Index()
 

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	ras "app/tools"
@@ -30,7 +31,7 @@ func Index(fs *filestore.FileStore) echo.HandlerFunc {
 
 		rm, err := ras.NewRasModel(definitionFile, *fs)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error(), err.(*errors.Error).ErrorStack()})
+			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, fmt.Sprintf("Go error encountered: %v", err.Error()), err.(*errors.Error).ErrorStack()})
 		}
 		mod := rm.Index()
 

--- a/handlers/isgeospatial.go
+++ b/handlers/isgeospatial.go
@@ -6,6 +6,7 @@ import (
 	ras "app/tools"
 
 	"github.com/USACE/filestore"
+	"github.com/go-errors/errors" // warning: replaces standard errors
 	"github.com/labstack/echo/v4"
 )
 
@@ -28,7 +29,7 @@ func IsGeospatial(fs *filestore.FileStore) echo.HandlerFunc {
 
 		rm, err := ras.NewRasModel(definitionFile, *fs)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error()})
+			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error(), err.(*errors.Error).ErrorStack()})
 		}
 		isIt := rm.IsGeospatial()
 

--- a/handlers/isgeospatial.go
+++ b/handlers/isgeospatial.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	ras "app/tools"
@@ -29,7 +30,7 @@ func IsGeospatial(fs *filestore.FileStore) echo.HandlerFunc {
 
 		rm, err := ras.NewRasModel(definitionFile, *fs)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error(), err.(*errors.Error).ErrorStack()})
+			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, fmt.Sprintf("Go error encountered: %v", err.Error()), err.(*errors.Error).ErrorStack()})
 		}
 		isIt := rm.IsGeospatial()
 

--- a/handlers/modeltype.go
+++ b/handlers/modeltype.go
@@ -6,6 +6,7 @@ import (
 	ras "app/tools"
 
 	"github.com/USACE/filestore"
+	"github.com/go-errors/errors" // warning: replaces standard errors
 	"github.com/labstack/echo/v4"
 )
 
@@ -29,7 +30,7 @@ func ModelType(fs *filestore.FileStore) echo.HandlerFunc {
 
 		rm, err := ras.NewRasModel(definitionFile, *fs)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error()})
+			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error(), err.(*errors.Error).ErrorStack()})
 		}
 		typ := rm.ModelType()
 

--- a/handlers/modeltype.go
+++ b/handlers/modeltype.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	ras "app/tools"
@@ -30,7 +31,7 @@ func ModelType(fs *filestore.FileStore) echo.HandlerFunc {
 
 		rm, err := ras.NewRasModel(definitionFile, *fs)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error(), err.(*errors.Error).ErrorStack()})
+			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, fmt.Sprintf("Go error encountered: %v", err.Error()), err.(*errors.Error).ErrorStack()})
 		}
 		typ := rm.ModelType()
 

--- a/handlers/modelversion.go
+++ b/handlers/modelversion.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	ras "app/tools"
@@ -30,7 +31,7 @@ func ModelVersion(fs *filestore.FileStore) echo.HandlerFunc {
 
 		rm, err := ras.NewRasModel(definitionFile, *fs)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error(), err.(*errors.Error).ErrorStack()})
+			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, fmt.Sprintf("Go error encountered: %v", err.Error()), err.(*errors.Error).ErrorStack()})
 		}
 		vers := rm.ModelVersion()
 

--- a/handlers/modelversion.go
+++ b/handlers/modelversion.go
@@ -6,6 +6,7 @@ import (
 	ras "app/tools"
 
 	"github.com/USACE/filestore"
+	"github.com/go-errors/errors" // warning: replaces standard errors
 	"github.com/labstack/echo/v4"
 )
 
@@ -29,7 +30,7 @@ func ModelVersion(fs *filestore.FileStore) echo.HandlerFunc {
 
 		rm, err := ras.NewRasModel(definitionFile, *fs)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error()})
+			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, err.Error(), err.(*errors.Error).ErrorStack()})
 		}
 		vers := rm.ModelVersion()
 

--- a/handlers/ping.go
+++ b/handlers/ping.go
@@ -9,8 +9,9 @@ import (
 )
 
 type SimpleResponse struct {
-	Status  int
-	Message string
+	Status  	 int
+	Message 	 string
+	StackTrace   string
 }
 
 // Ping godoc

--- a/pgdb/handler.go
+++ b/pgdb/handler.go
@@ -3,6 +3,7 @@ package pgdb
 import (
 	"app/config"
 	"app/handlers"
+	"fmt"
 	"net/http"
 
 	"github.com/go-errors/errors" // warning: replaces standard errors
@@ -24,7 +25,7 @@ func UpsertRasModel(ac *config.APIConfig, db *sqlx.DB) echo.HandlerFunc {
 
 		err := upsertModelInfo(definitionFile, ac, db)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, handlers.SimpleResponse{Status: http.StatusInternalServerError, Message: err.Error(), StackTrace: err.(*errors.Error).ErrorStack()})
+			return c.JSON(http.StatusInternalServerError, handlers.SimpleResponse{Status: http.StatusInternalServerError, Message: fmt.Sprintf("Go error encountered: %v", err.Error()), StackTrace: err.(*errors.Error).ErrorStack()})
 		}
 
 		return c.JSON(http.StatusOK, "Successfully uploaded model information for "+definitionFile)
@@ -45,7 +46,7 @@ func UpsertRasGeometry(ac *config.APIConfig, db *sqlx.DB) echo.HandlerFunc {
 
 		err := upsertModelGeometry(definitionFile, ac, db)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, handlers.SimpleResponse{Status: http.StatusInternalServerError, Message: err.Error(), StackTrace: err.(*errors.Error).ErrorStack()})
+			return c.JSON(http.StatusInternalServerError, handlers.SimpleResponse{Status: http.StatusInternalServerError, Message: fmt.Sprintf("Go error encountered: %v", err.Error()), StackTrace: err.(*errors.Error).ErrorStack()})
 		}
 
 		return c.JSON(http.StatusOK, "Successfully uploaded model geometry for "+definitionFile)
@@ -59,7 +60,7 @@ func VacuumRasViews(db *sqlx.DB) echo.HandlerFunc {
 		for _, query := range vacuumQuery {
 			_, err := db.Exec(query)
 			if err != nil {
-				return c.JSON(http.StatusInternalServerError, handlers.SimpleResponse{Status: http.StatusInternalServerError, Message: err.Error(), StackTrace: err.(*errors.Error).ErrorStack()})
+				return c.JSON(http.StatusInternalServerError, handlers.SimpleResponse{Status: http.StatusInternalServerError, Message: fmt.Sprintf("Go error encountered: %v", err.Error()), StackTrace: err.(*errors.Error).ErrorStack()})
 			}
 		}
 
@@ -74,7 +75,7 @@ func RefreshRasViews(db *sqlx.DB) echo.HandlerFunc {
 		for _, query := range refreshViewsQuery {
 			_, err := db.Exec(query)
 			if err != nil {
-				return c.JSON(http.StatusInternalServerError, handlers.SimpleResponse{Status: http.StatusInternalServerError, Message: err.Error(), StackTrace: err.(*errors.Error).ErrorStack()})
+				return c.JSON(http.StatusInternalServerError, handlers.SimpleResponse{Status: http.StatusInternalServerError, Message: fmt.Sprintf("Go error encountered: %v", err.Error()), StackTrace: err.(*errors.Error).ErrorStack()})
 			}
 		}
 

--- a/pgdb/handler.go
+++ b/pgdb/handler.go
@@ -5,14 +5,10 @@ import (
 	"app/handlers"
 	"net/http"
 
+	"github.com/go-errors/errors" // warning: replaces standard errors
 	"github.com/jmoiron/sqlx"
 	"github.com/labstack/echo/v4"
 )
-
-type simpleResponse struct {
-	Status  int
-	Message string
-}
 
 // UpsertRasModel ...
 func UpsertRasModel(ac *config.APIConfig, db *sqlx.DB) echo.HandlerFunc {
@@ -28,7 +24,7 @@ func UpsertRasModel(ac *config.APIConfig, db *sqlx.DB) echo.HandlerFunc {
 
 		err := upsertModelInfo(definitionFile, ac, db)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, simpleResponse{http.StatusInternalServerError, err.Error()})
+			return c.JSON(http.StatusInternalServerError, handlers.SimpleResponse{Status: http.StatusInternalServerError, Message: err.Error(), StackTrace: err.(*errors.Error).ErrorStack()})
 		}
 
 		return c.JSON(http.StatusOK, "Successfully uploaded model information for "+definitionFile)
@@ -44,12 +40,12 @@ func UpsertRasGeometry(ac *config.APIConfig, db *sqlx.DB) echo.HandlerFunc {
 		if definitionFile == "" {
 			return c.JSON(http.StatusBadRequest,
 				handlers.SimpleResponse{Status: http.StatusBadRequest,
-					Message: "Missing query parameter: `definition_file`"})
+					Message: "Missing query parameter: `definition_file`", })
 		}
 
 		err := upsertModelGeometry(definitionFile, ac, db)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, simpleResponse{http.StatusInternalServerError, err.Error()})
+			return c.JSON(http.StatusInternalServerError, handlers.SimpleResponse{Status: http.StatusInternalServerError, Message: err.Error(), StackTrace: err.(*errors.Error).ErrorStack()})
 		}
 
 		return c.JSON(http.StatusOK, "Successfully uploaded model geometry for "+definitionFile)
@@ -63,7 +59,7 @@ func VacuumRasViews(db *sqlx.DB) echo.HandlerFunc {
 		for _, query := range vacuumQuery {
 			_, err := db.Exec(query)
 			if err != nil {
-				return c.JSON(http.StatusInternalServerError, simpleResponse{http.StatusInternalServerError, err.Error()})
+				return c.JSON(http.StatusInternalServerError, handlers.SimpleResponse{Status: http.StatusInternalServerError, Message: err.Error(), StackTrace: err.(*errors.Error).ErrorStack()})
 			}
 		}
 
@@ -78,7 +74,7 @@ func RefreshRasViews(db *sqlx.DB) echo.HandlerFunc {
 		for _, query := range refreshViewsQuery {
 			_, err := db.Exec(query)
 			if err != nil {
-				return c.JSON(http.StatusInternalServerError, simpleResponse{http.StatusInternalServerError, err.Error()})
+				return c.JSON(http.StatusInternalServerError, handlers.SimpleResponse{Status: http.StatusInternalServerError, Message: err.Error(), StackTrace: err.(*errors.Error).ErrorStack()})
 			}
 		}
 

--- a/pgdb/tools.go
+++ b/pgdb/tools.go
@@ -26,14 +26,14 @@ type ETLMetaData struct {
 func getCollectionID(tx *sqlx.Tx, definitionFile string) (collectionID int, err error) {
 
 	if err := tx.Get(&collectionID, getCollectionIDSQL, definitionFile); err != nil {
-		return 0, errors.Wrap(err, 1)
+		return 0, errors.Wrap(err, 0)
 	}
 	return collectionID, nil
 }
 
 func getModelID(tx *sqlx.Tx, definitionFile string) (modelID int, err error) {
 	if err := tx.Get(&modelID, getModelIDSQL, definitionFile); err != nil {
-		return 0, errors.Wrap(err, 1)
+		return 0, errors.Wrap(err, 0)
 	}
 	return modelID, nil
 }
@@ -46,16 +46,16 @@ func upsertModel(tx *sqlx.Tx, rm *ras.RasModel, definitionFile string, collectio
 
 	etlMeta, err := json.Marshal(etlMetaRaw)
 	if err != nil {
-		return 0, errors.Wrap(err, 1)
+		return 0, errors.Wrap(err, 0)
 	}
 
 	modelMeta, err := json.Marshal(rm.Metadata)
 	if err != nil {
-		return 0, errors.Wrap(err, 1)
+		return 0, errors.Wrap(err, 0)
 	}
 
 	if err := tx.Get(&modelID, upsertModelSQL, collectionID, modelName, rm.Type, definitionFile, modelMeta, etlMeta); err != nil {
-		return 0, errors.Wrap(err, 1)
+		return 0, errors.Wrap(err, 0)
 	}
 
 	return modelID, nil
@@ -68,7 +68,7 @@ func upsertRiver(tx *sqlx.Tx, river ras.VectorLayer, geometryFileID int) (riverI
 	reachName := strings.TrimSpace(riverReach[1])
 
 	if err := tx.Get(&riverID, upsertRiversSQL, geometryFileID, riverName, reachName, river.Geometry); err != nil {
-		return 0, errors.Wrap(err, 1)
+		return 0, errors.Wrap(err, 0)
 	}
 	return riverID, nil
 }
@@ -78,18 +78,18 @@ func upsertModelInfo(definitionFile string, ac *config.APIConfig, db *sqlx.DB) e
 	tx, err := db.BeginTxx(ctx, nil)
 	if err != nil {
 		log.Println(err)
-		return errors.Wrap(err, 1)
+		return errors.Wrap(err, 0)
 	}
 
 	rm, err := ras.NewRasModel(definitionFile, *ac.FileStore)
 	if err != nil {
-		return errors.Wrap(err, 1)
+		return errors.Wrap(err, 0)
 	}
 
 	collectionID, err := getCollectionID(tx, definitionFile)
 	if err != nil {
 		log.Println("Collection ID:", collectionID, err)
-		return errors.Wrap(err, 1)
+		return errors.Wrap(err, 0)
 	}
 
 	modelID, err := upsertModel(tx, rm, definitionFile, collectionID)
@@ -97,14 +97,14 @@ func upsertModelInfo(definitionFile string, ac *config.APIConfig, db *sqlx.DB) e
 		fmt.Println("Model ID:", modelID, "Name|", definitionFile)
 		log.Println("Error: ", err, "Rolling back")
 		tx.Rollback()
-		return errors.Wrap(err, 1)
+		return errors.Wrap(err, 0)
 	}
 
 	err = tx.Commit()
 	if err != nil {
 		fmt.Println("Model ID:", modelID, "Name|", definitionFile)
 		log.Println("Transaction Commit Error|", err)
-		return errors.Wrap(err, 1)
+		return errors.Wrap(err, 0)
 	}
 
 	return nil
@@ -115,26 +115,26 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 	tx, err := db.BeginTxx(ctx, nil)
 	if err != nil {
 		log.Println(err)
-		return errors.Wrap(err, 1)
+		return errors.Wrap(err, 0)
 	}
 
 	rm, err := ras.NewRasModel(definitionFile, *ac.FileStore)
 	if err != nil {
-		return errors.Wrap(err, 1)
+		return errors.Wrap(err, 0)
 	}
 
 	modelID, err := getModelID(tx, definitionFile)
 	fmt.Println("Model ID:", modelID, "Name|", definitionFile)
 	if err != nil {
 		log.Println(err)
-		return errors.Wrap(err, 1)
+		return errors.Wrap(err, 0)
 	}
 
 	if rm.IsGeospatial() {
 
 		geodata, err := rm.GeospatialData(ac.DestinationCRS)
 		if err != nil {
-			return errors.Wrap(err, 1)
+			return errors.Wrap(err, 0)
 		}
 
 		// Iterate over geometry files
@@ -156,7 +156,7 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 				geometryFile.Description); err != nil {
 				log.Println("Geometry File", geometryFile.FileExt, "|", err)
 				tx.Rollback()
-				return errors.Wrap(err, 1)
+				return errors.Wrap(err, 0)
 			}
 
 			// Iterate over features in geometry file and add to tables as needed
@@ -172,7 +172,7 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 				if err != nil {
 					log.Println(err)
 					tx.Rollback()
-					return errors.Wrap(err, 1)
+					return errors.Wrap(err, 0)
 				}
 				riverIDMap[river.FeatureName] = riverID
 			}
@@ -187,14 +187,14 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 				if err != nil {
 					log.Println("XS", geometryFile.FileExt, "|", err)
 					tx.Rollback()
-					return errors.Wrap(err, 1)
+					return errors.Wrap(err, 0)
 				}
 
 				riverID := riverIDMap[riverReach.(string)]
 				if err = tx.Get(&xsID, upsertXSSQL, riverID, xsStation, cutLineProfileMatch, xs.Geometry); err != nil {
 					log.Println(err)
 					tx.Rollback()
-					return errors.Wrap(err, 1)
+					return errors.Wrap(err, 0)
 				}
 				riverReachXSName := fmt.Sprintf("%s-%s", riverReach, xs.FeatureName)
 				xsIDMap[riverReachXSName] = xsID
@@ -206,14 +206,14 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 				xsID := xsIDMap[riverReachXSName]
 				bankStation, err := strconv.ParseFloat(banks.FeatureName, 64)
 				if err != nil {
-					return errors.Wrap(err, 1)
+					return errors.Wrap(err, 0)
 				}
 
 				_, err = tx.Exec(upsertBanksSQL, xsID, bankStation, banks.Geometry)
 				if err != nil {
 					log.Println("Banks", geometryFile.FileExt, "|", err)
 					tx.Rollback()
-					return errors.Wrap(err, 1)
+					return errors.Wrap(err, 0)
 				}
 			}
 
@@ -223,7 +223,7 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 				if err != nil {
 					log.Println("Storage Areas", geometryFile.FileExt, "|", err)
 					tx.Rollback()
-					return errors.Wrap(err, 1)
+					return errors.Wrap(err, 0)
 				}
 			}
 		}
@@ -231,7 +231,7 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 		err = tx.Commit()
 		if err != nil {
 			log.Println("Transaction Commit Error|", err)
-			return errors.Wrap(err, 1)
+			return errors.Wrap(err, 0)
 		}
 
 	}

--- a/pgdb/tools.go
+++ b/pgdb/tools.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/go-errors/errors" // warning: replaces standard errors
 	"github.com/jmoiron/sqlx"
 )
 
@@ -25,14 +26,14 @@ type ETLMetaData struct {
 func getCollectionID(tx *sqlx.Tx, definitionFile string) (collectionID int, err error) {
 
 	if err := tx.Get(&collectionID, getCollectionIDSQL, definitionFile); err != nil {
-		return 0, err
+		return 0, errors.Wrap(err, 1)
 	}
 	return collectionID, nil
 }
 
 func getModelID(tx *sqlx.Tx, definitionFile string) (modelID int, err error) {
 	if err := tx.Get(&modelID, getModelIDSQL, definitionFile); err != nil {
-		return 0, err
+		return 0, errors.Wrap(err, 1)
 	}
 	return modelID, nil
 }
@@ -45,16 +46,16 @@ func upsertModel(tx *sqlx.Tx, rm *ras.RasModel, definitionFile string, collectio
 
 	etlMeta, err := json.Marshal(etlMetaRaw)
 	if err != nil {
-		return 0, err
+		return 0, errors.Wrap(err, 1)
 	}
 
 	modelMeta, err := json.Marshal(rm.Metadata)
 	if err != nil {
-		return 0, err
+		return 0, errors.Wrap(err, 1)
 	}
 
 	if err := tx.Get(&modelID, upsertModelSQL, collectionID, modelName, rm.Type, definitionFile, modelMeta, etlMeta); err != nil {
-		return 0, err
+		return 0, errors.Wrap(err, 1)
 	}
 
 	return modelID, nil
@@ -67,7 +68,7 @@ func upsertRiver(tx *sqlx.Tx, river ras.VectorLayer, geometryFileID int) (riverI
 	reachName := strings.TrimSpace(riverReach[1])
 
 	if err := tx.Get(&riverID, upsertRiversSQL, geometryFileID, riverName, reachName, river.Geometry); err != nil {
-		return 0, err
+		return 0, errors.Wrap(err, 1)
 	}
 	return riverID, nil
 }
@@ -77,18 +78,18 @@ func upsertModelInfo(definitionFile string, ac *config.APIConfig, db *sqlx.DB) e
 	tx, err := db.BeginTxx(ctx, nil)
 	if err != nil {
 		log.Println(err)
-		return err
+		return errors.Wrap(err, 1)
 	}
 
 	rm, err := ras.NewRasModel(definitionFile, *ac.FileStore)
 	if err != nil {
-		return err
+		return errors.Wrap(err, 1)
 	}
 
 	collectionID, err := getCollectionID(tx, definitionFile)
 	if err != nil {
 		log.Println("Collection ID:", collectionID, err)
-		return err
+		return errors.Wrap(err, 1)
 	}
 
 	modelID, err := upsertModel(tx, rm, definitionFile, collectionID)
@@ -96,14 +97,14 @@ func upsertModelInfo(definitionFile string, ac *config.APIConfig, db *sqlx.DB) e
 		fmt.Println("Model ID:", modelID, "Name|", definitionFile)
 		log.Println("Error: ", err, "Rolling back")
 		tx.Rollback()
-		return err
+		return errors.Wrap(err, 1)
 	}
 
 	err = tx.Commit()
 	if err != nil {
 		fmt.Println("Model ID:", modelID, "Name|", definitionFile)
 		log.Println("Transaction Commit Error|", err)
-		return err
+		return errors.Wrap(err, 1)
 	}
 
 	return nil
@@ -114,26 +115,26 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 	tx, err := db.BeginTxx(ctx, nil)
 	if err != nil {
 		log.Println(err)
-		return err
+		return errors.Wrap(err, 1)
 	}
 
 	rm, err := ras.NewRasModel(definitionFile, *ac.FileStore)
 	if err != nil {
-		return err
+		return errors.Wrap(err, 1)
 	}
 
 	modelID, err := getModelID(tx, definitionFile)
 	fmt.Println("Model ID:", modelID, "Name|", definitionFile)
 	if err != nil {
 		log.Println(err)
-		return err
+		return errors.Wrap(err, 1)
 	}
 
 	if rm.IsGeospatial() {
 
 		geodata, err := rm.GeospatialData(ac.DestinationCRS)
 		if err != nil {
-			return err
+			return errors.Wrap(err, 1)
 		}
 
 		// Iterate over geometry files
@@ -155,7 +156,7 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 				geometryFile.Description); err != nil {
 				log.Println("Geometry File", geometryFile.FileExt, "|", err)
 				tx.Rollback()
-				return err
+				return errors.Wrap(err, 1)
 			}
 
 			// Iterate over features in geometry file and add to tables as needed
@@ -171,7 +172,7 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 				if err != nil {
 					log.Println(err)
 					tx.Rollback()
-					return err
+					return errors.Wrap(err, 1)
 				}
 				riverIDMap[river.FeatureName] = riverID
 			}
@@ -186,14 +187,14 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 				if err != nil {
 					log.Println("XS", geometryFile.FileExt, "|", err)
 					tx.Rollback()
-					return err
+					return errors.Wrap(err, 1)
 				}
 
 				riverID := riverIDMap[riverReach.(string)]
 				if err = tx.Get(&xsID, upsertXSSQL, riverID, xsStation, cutLineProfileMatch, xs.Geometry); err != nil {
 					log.Println(err)
 					tx.Rollback()
-					return err
+					return errors.Wrap(err, 1)
 				}
 				riverReachXSName := fmt.Sprintf("%s-%s", riverReach, xs.FeatureName)
 				xsIDMap[riverReachXSName] = xsID
@@ -205,14 +206,14 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 				xsID := xsIDMap[riverReachXSName]
 				bankStation, err := strconv.ParseFloat(banks.FeatureName, 64)
 				if err != nil {
-					return err
+					return errors.Wrap(err, 1)
 				}
 
 				_, err = tx.Exec(upsertBanksSQL, xsID, bankStation, banks.Geometry)
 				if err != nil {
 					log.Println("Banks", geometryFile.FileExt, "|", err)
 					tx.Rollback()
-					return err
+					return errors.Wrap(err, 1)
 				}
 			}
 
@@ -222,7 +223,7 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 				if err != nil {
 					log.Println("Storage Areas", geometryFile.FileExt, "|", err)
 					tx.Rollback()
-					return err
+					return errors.Wrap(err, 1)
 				}
 			}
 		}
@@ -230,7 +231,7 @@ func upsertModelGeometry(definitionFile string, ac *config.APIConfig, db *sqlx.D
 		err = tx.Commit()
 		if err != nil {
 			log.Println("Transaction Commit Error|", err)
-			return err
+			return errors.Wrap(err, 1)
 		}
 
 	}

--- a/tools/geospatial.go
+++ b/tools/geospatial.go
@@ -71,11 +71,11 @@ out:
 			if len(line) > s {
 				val1, err := parseFloat(strings.TrimSpace(line[s:s+valueWidth]), 64)
 				if err != nil {
-					return pairs, errors.Wrap(err, 1)
+					return pairs, errors.Wrap(err, 0)
 				}
 				val2, err := parseFloat(strings.TrimSpace(line[s+valueWidth:s+stride]), 64)
 				if err != nil {
-					return pairs, errors.Wrap(err, 1)
+					return pairs, errors.Wrap(err, 0)
 				}
 				pairs = append(pairs, [2]float64{val1, val2})
 				if len(pairs) == nPairs {
@@ -97,11 +97,11 @@ func getDataPairsfromTextBlock(nDataPairsLine string, sc *bufio.Scanner, colWidt
 		if strings.HasPrefix(line, nDataPairsLine) {
 			nPairs, err := strconv.Atoi(rightofEquals(line))
 			if err != nil {
-				return pairs, errors.Wrap(err, 1)
+				return pairs, errors.Wrap(err, 0)
 			}
 			pairs, err = dataPairsfromTextBlock(sc, nPairs, colWidth, valueWidth)
 			if err != nil {
-				return pairs, errors.Wrap(err, 1)
+				return pairs, errors.Wrap(err, 0)
 			}
 			break
 		}
@@ -178,7 +178,7 @@ func getTransform(sourceCRS string, destinationCRS int) (gdal.CoordinateTransfor
 
 	destinationSpRef := gdal.CreateSpatialReference("")
 	if err := destinationSpRef.FromEPSG(destinationCRS); err != nil {
-		return transform, errors.Wrap(err, 1)
+		return transform, errors.Wrap(err, 0)
 	}
 	transform = gdal.CreateCoordinateTransform(sourceSpRef, destinationSpRef)
 	return transform, nil
@@ -231,7 +231,7 @@ func flipXYPoint(xyPoint gdal.Geometry) gdal.Geometry {
 func toNumeric(s string) (string, error) {
 	reg, err := regexp.Compile("[^.0-9]+")
 	if err != nil {
-		return s, errors.Wrap(err, 1)
+		return s, errors.Wrap(err, 0)
 	}
 	num := reg.ReplaceAllString(s, "")
 	return num, nil
@@ -243,7 +243,7 @@ func getRiverCenterline(sc *bufio.Scanner, transform gdal.CoordinateTransform) (
 
 	xyPairs, err := getDataPairsfromTextBlock("Reach XY=", sc, 64, 16)
 	if err != nil {
-		return layer, errors.Wrap(err, 1)
+		return layer, errors.Wrap(err, 0)
 	}
 
 	xyLineString := gdal.Create(gdal.GT_LineString)
@@ -259,10 +259,10 @@ func getRiverCenterline(sc *bufio.Scanner, transform gdal.CoordinateTransform) (
 
 	wkb, err := multiLineString.ToWKB()
 	if err != nil {
-		return layer, errors.Wrap(err, 1)
+		return layer, errors.Wrap(err, 0)
 	}
 	layer.Geometry = wkb
-	return layer, errors.Wrap(err, 1)
+	return layer, errors.Wrap(err, 0)
 }
 
 func getXSBanks(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReachName string) (VectorLayer, []VectorLayer, error) {
@@ -270,7 +270,7 @@ func getXSBanks(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReac
 
 	xsLayer, xyPairs, startingStation, err := getXS(sc, transform, riverReachName)
 	if err != nil {
-		return xsLayer, bankLayers, errors.Wrap(err, 1)
+		return xsLayer, bankLayers, errors.Wrap(err, 0)
 	}
 
 	if xsLayer.Fields["CutLineProfileMatch"].(bool) {
@@ -279,14 +279,14 @@ func getXSBanks(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReac
 			if strings.HasPrefix(line, "Bank Sta=") {
 				bankLayers, err = getBanks(line, transform, xsLayer, xyPairs, startingStation)
 				if err != nil {
-					return xsLayer, bankLayers, errors.Wrap(err, 1)
+					return xsLayer, bankLayers, errors.Wrap(err, 0)
 				}
 				break
 			}
 		}
 	}
 
-	return xsLayer, bankLayers, errors.Wrap(err, 1)
+	return xsLayer, bankLayers, errors.Wrap(err, 0)
 }
 
 func getXS(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReachName string) (VectorLayer, [][2]float64, float64, error) {
@@ -299,18 +299,18 @@ func getXS(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReachName
 
 	xsName, err := toNumeric(compData[1])
 	if err != nil {
-		return layer, xyPairs, 0.0, errors.Wrap(err, 1)
+		return layer, xyPairs, 0.0, errors.Wrap(err, 0)
 	}
 	layer.FeatureName = xsName
 
 	xyPairs, err = getDataPairsfromTextBlock("XS GIS Cut Line", sc, 64, 16)
 	if err != nil {
-		return layer, xyPairs, 0.0, errors.Wrap(err, 1)
+		return layer, xyPairs, 0.0, errors.Wrap(err, 0)
 	}
 
 	if len(xyPairs) < 2 {
 		err = errors.New("the cross-section cutline could not be extracted, check that the geometry file contains cutlines")
-		return layer, xyPairs, 0.0, errors.Wrap(err, 1)
+		return layer, xyPairs, 0.0, errors.Wrap(err, 0)
 	}
 
 	xyzLineString := gdal.Create(gdal.GT_LineString25D)
@@ -321,7 +321,7 @@ func getXS(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReachName
 
 	mzPairs, err := getDataPairsfromTextBlock("#Sta/Elev", sc, 80, 8)
 	if err != nil {
-		return layer, xyPairs, mzPairs[0][0], errors.Wrap(err, 1)
+		return layer, xyPairs, mzPairs[0][0], errors.Wrap(err, 0)
 	}
 
 	if len(mzPairs) >= 2 {
@@ -343,10 +343,10 @@ func getXS(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReachName
 	multiLineString := yxzLineString.ForceToMultiLineString()
 	wkb, err := multiLineString.ToWKB()
 	if err != nil {
-		return layer, xyPairs, mzPairs[0][0], errors.Wrap(err, 1)
+		return layer, xyPairs, mzPairs[0][0], errors.Wrap(err, 0)
 	}
 	layer.Geometry = wkb
-	return layer, xyPairs, mzPairs[0][0], errors.Wrap(err, 1)
+	return layer, xyPairs, mzPairs[0][0], errors.Wrap(err, 0)
 }
 
 func getBanks(line string, transform gdal.CoordinateTransform, xsLayer VectorLayer, xyPairs [][2]float64, startingStation float64) ([]VectorLayer, error) {
@@ -359,7 +359,7 @@ func getBanks(line string, transform gdal.CoordinateTransform, xsLayer VectorLay
 		layer.Fields["xsName"] = xsLayer.FeatureName
 		bankStation, err := parseFloat(s, 64)
 		if err != nil {
-			return layers, errors.Wrap(err, 1)
+			return layers, errors.Wrap(err, 0)
 		}
 		bankXY := interpXY(xyPairs, bankStation-startingStation)
 		xyPoint := gdal.Create(gdal.GT_Point)
@@ -370,7 +370,7 @@ func getBanks(line string, transform gdal.CoordinateTransform, xsLayer VectorLay
 		multiPoint := yxPoint.ForceToMultiPoint()
 		wkb, err := multiPoint.ToWKB()
 		if err != nil {
-			return layers, errors.Wrap(err, 1)
+			return layers, errors.Wrap(err, 0)
 		}
 		layer.Geometry = wkb
 		layers = append(layers, layer)
@@ -383,7 +383,7 @@ func getStorageArea(sc *bufio.Scanner, transform gdal.CoordinateTransform) (Vect
 
 	xyPairs, err := getDataPairsfromTextBlock("Storage Area Surface Line=", sc, 32, 16)
 	if err != nil {
-		return layer, errors.Wrap(err, 1)
+		return layer, errors.Wrap(err, 0)
 	}
 
 	xyLinearRing := gdal.Create(gdal.GT_LinearRing)
@@ -400,10 +400,10 @@ func getStorageArea(sc *bufio.Scanner, transform gdal.CoordinateTransform) (Vect
 	yxMultiPolygon := yxPolygon.ForceToMultiPolygon()
 	wkb, err := yxMultiPolygon.ToWKB()
 	if err != nil {
-		return layer, errors.Wrap(err, 1)
+		return layer, errors.Wrap(err, 0)
 	}
 	layer.Geometry = wkb
-	return layer, errors.Wrap(err, 1)
+	return layer, errors.Wrap(err, 0)
 }
 
 // GetGeospatialData ...
@@ -414,7 +414,7 @@ func GetGeospatialData(gd *GeoData, fs filestore.FileStore, geomFilePath string,
 
 	file, err := fs.GetObject(geomFilePath)
 	if err != nil {
-		return errors.Wrap(err, 1) 
+		return errors.Wrap(err, 0) 
 	}
 	defer file.Close()
 
@@ -422,7 +422,7 @@ func GetGeospatialData(gd *GeoData, fs filestore.FileStore, geomFilePath string,
 
 	transform, err := getTransform(sourceCRS, destinationCRS)
 	if err != nil {
-		return errors.Wrap(err, 1) 
+		return errors.Wrap(err, 0) 
 	}
 
 	for sc.Scan() {
@@ -432,7 +432,7 @@ func GetGeospatialData(gd *GeoData, fs filestore.FileStore, geomFilePath string,
 		case strings.HasPrefix(line, "River Reach="):
 			riverLayer, err := getRiverCenterline(sc, transform)
 			if err != nil {
-				return errors.Wrap(err, 1) 
+				return errors.Wrap(err, 0) 
 			}
 			f.Rivers = append(f.Rivers, riverLayer)
 			riverReachName = riverLayer.FeatureName
@@ -440,14 +440,14 @@ func GetGeospatialData(gd *GeoData, fs filestore.FileStore, geomFilePath string,
 		case strings.HasPrefix(line, "Storage Area="):
 			storageAreaLayer, err := getStorageArea(sc, transform)
 			if err != nil {
-				return errors.Wrap(err, 1) 
+				return errors.Wrap(err, 0) 
 			}
 			f.StorageAreas = append(f.StorageAreas, storageAreaLayer)
 
 		case strings.HasPrefix(line, "Type RM Length L Ch R = 1"):
 			xsLayer, bankLayers, err := getXSBanks(sc, transform, riverReachName)
 			if err != nil {
-				return errors.Wrap(err, 1) 
+				return errors.Wrap(err, 0) 
 			}
 			f.XS = append(f.XS, xsLayer)
 			f.Banks = append(f.Banks, bankLayers...)

--- a/tools/geospatial.go
+++ b/tools/geospatial.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"math"
 	"path/filepath"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/USACE/filestore"
 	"github.com/dewberry/gdal"
+	"github.com/go-errors/errors" // warning: replaces standard errors
 )
 
 // GeoData ...
@@ -71,11 +71,11 @@ out:
 			if len(line) > s {
 				val1, err := parseFloat(strings.TrimSpace(line[s:s+valueWidth]), 64)
 				if err != nil {
-					return pairs, err
+					return pairs, errors.Wrap(err, 1)
 				}
 				val2, err := parseFloat(strings.TrimSpace(line[s+valueWidth:s+stride]), 64)
 				if err != nil {
-					return pairs, err
+					return pairs, errors.Wrap(err, 1)
 				}
 				pairs = append(pairs, [2]float64{val1, val2})
 				if len(pairs) == nPairs {
@@ -97,11 +97,11 @@ func getDataPairsfromTextBlock(nDataPairsLine string, sc *bufio.Scanner, colWidt
 		if strings.HasPrefix(line, nDataPairsLine) {
 			nPairs, err := strconv.Atoi(rightofEquals(line))
 			if err != nil {
-				return pairs, err
+				return pairs, errors.Wrap(err, 1)
 			}
 			pairs, err = dataPairsfromTextBlock(sc, nPairs, colWidth, valueWidth)
 			if err != nil {
-				return pairs, err
+				return pairs, errors.Wrap(err, 1)
 			}
 			break
 		}
@@ -178,7 +178,7 @@ func getTransform(sourceCRS string, destinationCRS int) (gdal.CoordinateTransfor
 
 	destinationSpRef := gdal.CreateSpatialReference("")
 	if err := destinationSpRef.FromEPSG(destinationCRS); err != nil {
-		return transform, err
+		return transform, errors.Wrap(err, 1)
 	}
 	transform = gdal.CreateCoordinateTransform(sourceSpRef, destinationSpRef)
 	return transform, nil
@@ -231,7 +231,7 @@ func flipXYPoint(xyPoint gdal.Geometry) gdal.Geometry {
 func toNumeric(s string) (string, error) {
 	reg, err := regexp.Compile("[^.0-9]+")
 	if err != nil {
-		return s, err
+		return s, errors.Wrap(err, 1)
 	}
 	num := reg.ReplaceAllString(s, "")
 	return num, nil
@@ -243,7 +243,7 @@ func getRiverCenterline(sc *bufio.Scanner, transform gdal.CoordinateTransform) (
 
 	xyPairs, err := getDataPairsfromTextBlock("Reach XY=", sc, 64, 16)
 	if err != nil {
-		return layer, err
+		return layer, errors.Wrap(err, 1)
 	}
 
 	xyLineString := gdal.Create(gdal.GT_LineString)
@@ -259,10 +259,10 @@ func getRiverCenterline(sc *bufio.Scanner, transform gdal.CoordinateTransform) (
 
 	wkb, err := multiLineString.ToWKB()
 	if err != nil {
-		return layer, err
+		return layer, errors.Wrap(err, 1)
 	}
 	layer.Geometry = wkb
-	return layer, err
+	return layer, errors.Wrap(err, 1)
 }
 
 func getXSBanks(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReachName string) (VectorLayer, []VectorLayer, error) {
@@ -270,7 +270,7 @@ func getXSBanks(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReac
 
 	xsLayer, xyPairs, startingStation, err := getXS(sc, transform, riverReachName)
 	if err != nil {
-		return xsLayer, bankLayers, err
+		return xsLayer, bankLayers, errors.Wrap(err, 1)
 	}
 
 	if xsLayer.Fields["CutLineProfileMatch"].(bool) {
@@ -279,14 +279,14 @@ func getXSBanks(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReac
 			if strings.HasPrefix(line, "Bank Sta=") {
 				bankLayers, err = getBanks(line, transform, xsLayer, xyPairs, startingStation)
 				if err != nil {
-					return xsLayer, bankLayers, err
+					return xsLayer, bankLayers, errors.Wrap(err, 1)
 				}
 				break
 			}
 		}
 	}
 
-	return xsLayer, bankLayers, err
+	return xsLayer, bankLayers, errors.Wrap(err, 1)
 }
 
 func getXS(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReachName string) (VectorLayer, [][2]float64, float64, error) {
@@ -299,18 +299,18 @@ func getXS(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReachName
 
 	xsName, err := toNumeric(compData[1])
 	if err != nil {
-		return layer, xyPairs, 0.0, err
+		return layer, xyPairs, 0.0, errors.Wrap(err, 1)
 	}
 	layer.FeatureName = xsName
 
 	xyPairs, err = getDataPairsfromTextBlock("XS GIS Cut Line", sc, 64, 16)
 	if err != nil {
-		return layer, xyPairs, 0.0, err
+		return layer, xyPairs, 0.0, errors.Wrap(err, 1)
 	}
 
 	if len(xyPairs) < 2 {
 		err = errors.New("the cross-section cutline could not be extracted, check that the geometry file contains cutlines")
-		return layer, xyPairs, 0.0, err
+		return layer, xyPairs, 0.0, errors.Wrap(err, 1)
 	}
 
 	xyzLineString := gdal.Create(gdal.GT_LineString25D)
@@ -321,7 +321,7 @@ func getXS(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReachName
 
 	mzPairs, err := getDataPairsfromTextBlock("#Sta/Elev", sc, 80, 8)
 	if err != nil {
-		return layer, xyPairs, mzPairs[0][0], err
+		return layer, xyPairs, mzPairs[0][0], errors.Wrap(err, 1)
 	}
 
 	if len(mzPairs) >= 2 {
@@ -343,10 +343,10 @@ func getXS(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReachName
 	multiLineString := yxzLineString.ForceToMultiLineString()
 	wkb, err := multiLineString.ToWKB()
 	if err != nil {
-		return layer, xyPairs, mzPairs[0][0], err
+		return layer, xyPairs, mzPairs[0][0], errors.Wrap(err, 1)
 	}
 	layer.Geometry = wkb
-	return layer, xyPairs, mzPairs[0][0], err
+	return layer, xyPairs, mzPairs[0][0], errors.Wrap(err, 1)
 }
 
 func getBanks(line string, transform gdal.CoordinateTransform, xsLayer VectorLayer, xyPairs [][2]float64, startingStation float64) ([]VectorLayer, error) {
@@ -359,7 +359,7 @@ func getBanks(line string, transform gdal.CoordinateTransform, xsLayer VectorLay
 		layer.Fields["xsName"] = xsLayer.FeatureName
 		bankStation, err := parseFloat(s, 64)
 		if err != nil {
-			return layers, err
+			return layers, errors.Wrap(err, 1)
 		}
 		bankXY := interpXY(xyPairs, bankStation-startingStation)
 		xyPoint := gdal.Create(gdal.GT_Point)
@@ -370,7 +370,7 @@ func getBanks(line string, transform gdal.CoordinateTransform, xsLayer VectorLay
 		multiPoint := yxPoint.ForceToMultiPoint()
 		wkb, err := multiPoint.ToWKB()
 		if err != nil {
-			return layers, err
+			return layers, errors.Wrap(err, 1)
 		}
 		layer.Geometry = wkb
 		layers = append(layers, layer)
@@ -383,7 +383,7 @@ func getStorageArea(sc *bufio.Scanner, transform gdal.CoordinateTransform) (Vect
 
 	xyPairs, err := getDataPairsfromTextBlock("Storage Area Surface Line=", sc, 32, 16)
 	if err != nil {
-		return layer, err
+		return layer, errors.Wrap(err, 1)
 	}
 
 	xyLinearRing := gdal.Create(gdal.GT_LinearRing)
@@ -400,10 +400,10 @@ func getStorageArea(sc *bufio.Scanner, transform gdal.CoordinateTransform) (Vect
 	yxMultiPolygon := yxPolygon.ForceToMultiPolygon()
 	wkb, err := yxMultiPolygon.ToWKB()
 	if err != nil {
-		return layer, err
+		return layer, errors.Wrap(err, 1)
 	}
 	layer.Geometry = wkb
-	return layer, err
+	return layer, errors.Wrap(err, 1)
 }
 
 // GetGeospatialData ...
@@ -414,7 +414,7 @@ func GetGeospatialData(gd *GeoData, fs filestore.FileStore, geomFilePath string,
 
 	file, err := fs.GetObject(geomFilePath)
 	if err != nil {
-		return err
+		return errors.Wrap(err, 1) 
 	}
 	defer file.Close()
 
@@ -422,7 +422,7 @@ func GetGeospatialData(gd *GeoData, fs filestore.FileStore, geomFilePath string,
 
 	transform, err := getTransform(sourceCRS, destinationCRS)
 	if err != nil {
-		return err
+		return errors.Wrap(err, 1) 
 	}
 
 	for sc.Scan() {
@@ -432,7 +432,7 @@ func GetGeospatialData(gd *GeoData, fs filestore.FileStore, geomFilePath string,
 		case strings.HasPrefix(line, "River Reach="):
 			riverLayer, err := getRiverCenterline(sc, transform)
 			if err != nil {
-				return err
+				return errors.Wrap(err, 1) 
 			}
 			f.Rivers = append(f.Rivers, riverLayer)
 			riverReachName = riverLayer.FeatureName
@@ -440,14 +440,14 @@ func GetGeospatialData(gd *GeoData, fs filestore.FileStore, geomFilePath string,
 		case strings.HasPrefix(line, "Storage Area="):
 			storageAreaLayer, err := getStorageArea(sc, transform)
 			if err != nil {
-				return err
+				return errors.Wrap(err, 1) 
 			}
 			f.StorageAreas = append(f.StorageAreas, storageAreaLayer)
 
 		case strings.HasPrefix(line, "Type RM Length L Ch R = 1"):
 			xsLayer, bankLayers, err := getXSBanks(sc, transform, riverReachName)
 			if err != nil {
-				return err
+				return errors.Wrap(err, 1) 
 			}
 			f.XS = append(f.XS, xsLayer)
 			f.Banks = append(f.Banks, bankLayers...)

--- a/tools/geospatial.go
+++ b/tools/geospatial.go
@@ -262,7 +262,7 @@ func getRiverCenterline(sc *bufio.Scanner, transform gdal.CoordinateTransform) (
 		return layer, errors.Wrap(err, 0)
 	}
 	layer.Geometry = wkb
-	return layer, errors.Wrap(err, 0)
+	return layer, nil
 }
 
 func getXSBanks(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReachName string) (VectorLayer, []VectorLayer, error) {
@@ -286,7 +286,7 @@ func getXSBanks(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReac
 		}
 	}
 
-	return xsLayer, bankLayers, errors.Wrap(err, 0)
+	return xsLayer, bankLayers, nil
 }
 
 func getXS(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReachName string) (VectorLayer, [][2]float64, float64, error) {
@@ -346,7 +346,7 @@ func getXS(sc *bufio.Scanner, transform gdal.CoordinateTransform, riverReachName
 		return layer, xyPairs, mzPairs[0][0], errors.Wrap(err, 0)
 	}
 	layer.Geometry = wkb
-	return layer, xyPairs, mzPairs[0][0], errors.Wrap(err, 0)
+	return layer, xyPairs, mzPairs[0][0], nil
 }
 
 func getBanks(line string, transform gdal.CoordinateTransform, xsLayer VectorLayer, xyPairs [][2]float64, startingStation float64) ([]VectorLayer, error) {
@@ -403,7 +403,7 @@ func getStorageArea(sc *bufio.Scanner, transform gdal.CoordinateTransform) (Vect
 		return layer, errors.Wrap(err, 0)
 	}
 	layer.Geometry = wkb
-	return layer, errors.Wrap(err, 0)
+	return layer, nil
 }
 
 // GetGeospatialData ...

--- a/tools/model.go
+++ b/tools/model.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/USACE/filestore"
 	"github.com/dewberry/gdal"
+	"github.com/go-errors/errors" // warning: replaces standard errors
 )
 
 type fileExtMatchers struct {
@@ -228,7 +228,7 @@ func (rm *RasModel) GeospatialData(destinationCRS int) (GeoData, error) {
 		sourceCRS := rm.Metadata.Projection
 
 		if err := checkUnitConsistency(modelUnits, sourceCRS); err != nil {
-			return gd, err
+			return gd, errors.Wrap(err, 1) 
 		}
 
 		gd.Features = make(map[string]Features)
@@ -236,13 +236,13 @@ func (rm *RasModel) GeospatialData(destinationCRS int) (GeoData, error) {
 
 		for _, g := range rm.Metadata.GeomFiles {
 			if err := GetGeospatialData(&gd, rm.FileStore, g.Path, sourceCRS, destinationCRS); err != nil {
-				return gd, err
+				return gd, errors.Wrap(err, 1) 
 			}
 		}
 		return gd, nil
 	}
 	err := errors.New("the model is not geospatial")
-	return gd, err
+	return gd, errors.Wrap(err, 1) 
 
 }
 
@@ -251,7 +251,7 @@ func getModelFiles(rm *RasModel) error {
 
 	files, err := rm.FileStore.GetDir(prefix, false)
 	if err != nil {
-		return err
+		return errors.Wrap(err, 1)
 	}
 
 	for _, file := range *files {
@@ -302,17 +302,17 @@ func NewRasModel(key string, fs filestore.FileStore) (*RasModel, error) {
 
 	err := verifyPrjPath(key, &rm)
 	if err != nil {
-		return &rm, err
+		return &rm, errors.Wrap(err, 1)
 	}
 
 	err = getModelFiles(&rm)
 	if err != nil {
-		return &rm, err
+		return &rm, errors.Wrap(err, 1)
 	}
 
 	err = getPrjData(&rm)
 	if err != nil {
-		return &rm, err
+		return &rm, errors.Wrap(err, 1)
 	}
 
 	var rasWG rasWaitGroup

--- a/tools/model.go
+++ b/tools/model.go
@@ -228,7 +228,7 @@ func (rm *RasModel) GeospatialData(destinationCRS int) (GeoData, error) {
 		sourceCRS := rm.Metadata.Projection
 
 		if err := checkUnitConsistency(modelUnits, sourceCRS); err != nil {
-			return gd, errors.Wrap(err, 1) 
+			return gd, errors.Wrap(err, 0) 
 		}
 
 		gd.Features = make(map[string]Features)
@@ -236,13 +236,13 @@ func (rm *RasModel) GeospatialData(destinationCRS int) (GeoData, error) {
 
 		for _, g := range rm.Metadata.GeomFiles {
 			if err := GetGeospatialData(&gd, rm.FileStore, g.Path, sourceCRS, destinationCRS); err != nil {
-				return gd, errors.Wrap(err, 1) 
+				return gd, errors.Wrap(err, 0) 
 			}
 		}
 		return gd, nil
 	}
 	err := errors.New("the model is not geospatial")
-	return gd, errors.Wrap(err, 1) 
+	return gd, errors.Wrap(err, 0) 
 
 }
 
@@ -251,7 +251,7 @@ func getModelFiles(rm *RasModel) error {
 
 	files, err := rm.FileStore.GetDir(prefix, false)
 	if err != nil {
-		return errors.Wrap(err, 1)
+		return errors.Wrap(err, 0)
 	}
 
 	for _, file := range *files {
@@ -302,17 +302,17 @@ func NewRasModel(key string, fs filestore.FileStore) (*RasModel, error) {
 
 	err := verifyPrjPath(key, &rm)
 	if err != nil {
-		return &rm, errors.Wrap(err, 1)
+		return &rm, errors.Wrap(err, 0)
 	}
 
 	err = getModelFiles(&rm)
 	if err != nil {
-		return &rm, errors.Wrap(err, 1)
+		return &rm, errors.Wrap(err, 0)
 	}
 
 	err = getPrjData(&rm)
 	if err != nil {
-		return &rm, errors.Wrap(err, 1)
+		return &rm, errors.Wrap(err, 0)
 	}
 
 	var rasWG rasWaitGroup

--- a/tools/project.go
+++ b/tools/project.go
@@ -45,7 +45,10 @@ func readFirstLine(fs filestore.FileStore, fn string) (string, error) {
 
 	reader := bufio.NewReader(file)
 	line, err := reader.ReadString('\n')
-	return rmNewLineChar(line), errors.Wrap(err, 0)
+	if err != nil {
+		return "", errors.Wrap(err, 0)
+	}
+	return rmNewLineChar(line), nil
 }
 
 func rmNewLineChar(s string) string {

--- a/tools/project.go
+++ b/tools/project.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/USACE/filestore"
+	"github.com/go-errors/errors" // warning: replaces standard errors
 )
 
 // ProjectMetadata contains information scraped from all files listed in the .prj file
@@ -38,13 +39,13 @@ func readFirstLine(fs filestore.FileStore, fn string) (string, error) {
 	file, err := fs.GetObject(fn)
 	if err != nil {
 		fmt.Println("Couldnt open the file", fn)
-		return "", err
+		return "", errors.Wrap(err, 1)
 	}
 	defer file.Close()
 
 	reader := bufio.NewReader(file)
 	line, err := reader.ReadString('\n')
-	return rmNewLineChar(line), err
+	return rmNewLineChar(line), errors.Wrap(err, 1)
 }
 
 func rmNewLineChar(s string) string {
@@ -55,15 +56,15 @@ func rmNewLineChar(s string) string {
 func verifyPrjPath(key string, rm *RasModel) error {
 
 	if filepath.Ext(key) != ".prj" {
-		return fmt.Errorf("%s is not a .prj file", key)
+		return errors.Errorf("%s is not a .prj file", key)
 	}
 
 	firstLine, err := readFirstLine(rm.FileStore, key)
 	if err != nil {
-		return err
+		return errors.Wrap(err, 1)
 	}
 	if !strings.Contains(firstLine, "Proj Title=") {
-		return fmt.Errorf("%s is not a RAS Project file", key)
+		return errors.Errorf("%s is not a RAS Project file", key)
 	}
 
 	rm.Metadata.ProjFilePath = key
@@ -78,7 +79,7 @@ func getPrjData(rm *RasModel) error {
 
 	f, err := rm.FileStore.GetObject(rm.Metadata.ProjFilePath)
 	if err != nil {
-		return err
+		return errors.Wrap(err, 1)
 	}
 	defer f.Close()
 
@@ -89,17 +90,17 @@ func getPrjData(rm *RasModel) error {
 
 		match, err := regexp.MatchString("=", line)
 		if err != nil {
-			return err
+			return errors.Wrap(err, 1)
 		}
 
 		beginDescription, err := regexp.MatchString("BEGIN DESCRIPTION", line)
 		if err != nil {
-			return err
+			return errors.Wrap(err, 1)
 		}
 
 		units, err := regexp.MatchString("Units", line)
 		if err != nil {
-			return err
+			return errors.Wrap(err, 1)
 		}
 
 		if match {

--- a/tools/project.go
+++ b/tools/project.go
@@ -39,13 +39,13 @@ func readFirstLine(fs filestore.FileStore, fn string) (string, error) {
 	file, err := fs.GetObject(fn)
 	if err != nil {
 		fmt.Println("Couldnt open the file", fn)
-		return "", errors.Wrap(err, 1)
+		return "", errors.Wrap(err, 0)
 	}
 	defer file.Close()
 
 	reader := bufio.NewReader(file)
 	line, err := reader.ReadString('\n')
-	return rmNewLineChar(line), errors.Wrap(err, 1)
+	return rmNewLineChar(line), errors.Wrap(err, 0)
 }
 
 func rmNewLineChar(s string) string {
@@ -61,7 +61,7 @@ func verifyPrjPath(key string, rm *RasModel) error {
 
 	firstLine, err := readFirstLine(rm.FileStore, key)
 	if err != nil {
-		return errors.Wrap(err, 1)
+		return errors.Wrap(err, 0)
 	}
 	if !strings.Contains(firstLine, "Proj Title=") {
 		return errors.Errorf("%s is not a RAS Project file", key)
@@ -79,7 +79,7 @@ func getPrjData(rm *RasModel) error {
 
 	f, err := rm.FileStore.GetObject(rm.Metadata.ProjFilePath)
 	if err != nil {
-		return errors.Wrap(err, 1)
+		return errors.Wrap(err, 0)
 	}
 	defer f.Close()
 
@@ -90,17 +90,17 @@ func getPrjData(rm *RasModel) error {
 
 		match, err := regexp.MatchString("=", line)
 		if err != nil {
-			return errors.Wrap(err, 1)
+			return errors.Wrap(err, 0)
 		}
 
 		beginDescription, err := regexp.MatchString("BEGIN DESCRIPTION", line)
 		if err != nil {
-			return errors.Wrap(err, 1)
+			return errors.Wrap(err, 0)
 		}
 
 		units, err := regexp.MatchString("Units", line)
 		if err != nil {
-			return errors.Wrap(err, 1)
+			return errors.Wrap(err, 0)
 		}
 
 		if match {

--- a/tools/structures.go
+++ b/tools/structures.go
@@ -125,7 +125,7 @@ out:
 					if nvalues%interval == 0 {
 						val, err := parseFloat(sVal, 64)
 						if err != nil {
-							return values, i, errors.Wrap(err, 1) 
+							return values, i, errors.Wrap(err, 0) 
 						}
 						values = append(values, val)
 					}
@@ -152,7 +152,7 @@ func getMaxMinElev(hsSc *bufio.Scanner, i int, nLines int, nSkipLines int, colWi
 	elevations, i, err := datafromTextBlock(hsSc, i, nLines, nSkipLines, colWidth, valueWidth, interval)
 
 	if err != nil {
-		return pair, i, errors.Wrap(err, 1) 
+		return pair, i, errors.Wrap(err, 0) 
 	}
 
 	if len(elevations) == 0 {
@@ -161,12 +161,12 @@ func getMaxMinElev(hsSc *bufio.Scanner, i int, nLines int, nSkipLines int, colWi
 
 	maxElev, err := maxValue(elevations)
 	if err != nil {
-		return pair, i, errors.Wrap(err, 1) 
+		return pair, i, errors.Wrap(err, 0) 
 	}
 
 	minElev, err := minValue(elevations)
 	if err != nil {
-		return pair, i, errors.Wrap(err, 1) 
+		return pair, i, errors.Wrap(err, 0) 
 	}
 
 	pair = maxMinPairs{Max: maxElev, Min: minElev}
@@ -183,20 +183,20 @@ func getHighLowChord(hsSc *bufio.Scanner, i int, nElevText string, colWidth int,
 
 	nElev, err := strconv.Atoi(strings.TrimSpace(nElevText))
 	if err != nil {
-		return highLowPairs, i, errors.Wrap(err, 1) 
+		return highLowPairs, i, errors.Wrap(err, 0) 
 	}
 
 	nLines := numberofLines(nElev, 80, 8)
 
 	highPair, i, err := getMaxMinElev(hsSc, i, nLines, nLines, 80, 8, 1)
 	if err != nil {
-		return highLowPairs, i, errors.Wrap(err, 1) 
+		return highLowPairs, i, errors.Wrap(err, 0) 
 	}
 	highLowPairs[0] = highPair
 
 	lowPair, i, err := getMaxMinElev(hsSc, i, nLines, 0, 80, 8, 1)
 	if err != nil {
-		return highLowPairs, i, errors.Wrap(err, 1) 
+		return highLowPairs, i, errors.Wrap(err, 0) 
 	}
 	highLowPairs[1] = lowPair
 
@@ -208,7 +208,7 @@ func stringtoFloat(s string) (float64, error) {
 	if trimmed != "" {
 		val, err := parseFloat(trimmed, 64)
 		if err != nil {
-			return 0, errors.Wrap(err, 1)
+			return 0, errors.Wrap(err, 0)
 		}
 		return val, nil
 	}
@@ -226,7 +226,7 @@ func getConduits(line string, single bool) (conduits, error) {
 	} else {
 		numbarrels, err := strconv.Atoi(strings.TrimSpace(lineData[11]))
 		if err != nil {
-			return conduit, errors.Wrap(err, 1) 
+			return conduit, errors.Wrap(err, 0) 
 
 		}
 		conduit.NumBarrels = numbarrels
@@ -235,35 +235,35 @@ func getConduits(line string, single bool) (conduits, error) {
 
 	shapeID, err := strconv.Atoi(strings.TrimSpace(lineData[0]))
 	if err != nil {
-		return conduit, errors.Wrap(err, 1) 
+		return conduit, errors.Wrap(err, 0) 
 
 	}
 	conduit.Shape = conduitShapes[shapeID]
 
 	rise, err := stringtoFloat(lineData[1])
 	if err != nil {
-		return conduit, errors.Wrap(err, 1) 
+		return conduit, errors.Wrap(err, 0) 
 
 	}
 	conduit.Rise = rise
 
 	span, err := stringtoFloat(lineData[2])
 	if err != nil {
-		return conduit, errors.Wrap(err, 1) 
+		return conduit, errors.Wrap(err, 0) 
 
 	}
 	conduit.Span = span
 
 	length, err := stringtoFloat(lineData[3])
 	if err != nil {
-		return conduit, errors.Wrap(err, 1) 
+		return conduit, errors.Wrap(err, 0) 
 
 	}
 	conduit.Length = length
 
 	mannings, err := stringtoFloat(lineData[4])
 	if err != nil {
-		return conduit, errors.Wrap(err, 1) 
+		return conduit, errors.Wrap(err, 0) 
 
 	}
 	conduit.ManningsN = mannings
@@ -276,7 +276,7 @@ func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, in
 
 	station, err := parseFloat(strings.TrimSpace(lineData[1]), 64)
 	if err != nil {
-		return culvert, i, errors.Wrap(err, 1) 
+		return culvert, i, errors.Wrap(err, 0) 
 	}
 	culvert.Station = station
 
@@ -288,7 +288,7 @@ func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, in
 			var description string
 			description, i, err = getDescription(hsSc, i, "END DESCRIPTION:")
 			if err != nil {
-				return culvert, i, errors.Wrap(err, 1) 
+				return culvert, i, errors.Wrap(err, 0) 
 			}
 			culvert.Description += description
 
@@ -301,14 +301,14 @@ func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, in
 			nextLineData := strings.Split(hsSc.Text(), ",")
 			deckWidth, err := parseFloat(strings.TrimSpace(nextLineData[0]), 64)
 			if err != nil {
-				return culvert, i, errors.Wrap(err, 1) 
+				return culvert, i, errors.Wrap(err, 0) 
 			}
 			culvert.DeckWidth = deckWidth
 
 			var upHighLowPair [2]maxMinPairs
 			upHighLowPair, i, err = getHighLowChord(hsSc, i, nextLineData[4], 80, 8)
 			if err != nil {
-				return culvert, i, errors.Wrap(err, 1) 
+				return culvert, i, errors.Wrap(err, 0) 
 			}
 			culvert.UpHighChord = upHighLowPair[0]
 			culvert.UpLowChord = upHighLowPair[1]
@@ -316,7 +316,7 @@ func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, in
 			var downHighLowPair [2]maxMinPairs
 			downHighLowPair, i, err = getHighLowChord(hsSc, i, nextLineData[5], 80, 8)
 			if err != nil {
-				return culvert, i, errors.Wrap(err, 1) 
+				return culvert, i, errors.Wrap(err, 0) 
 			}
 			culvert.DownHighChord = downHighLowPair[0]
 			culvert.DownLowChord = downHighLowPair[1]
@@ -324,7 +324,7 @@ func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, in
 		case strings.HasPrefix(line, "Culvert="):
 			conduit, err := getConduits(line, true)
 			if err != nil {
-				return culvert, i, errors.Wrap(err, 1) 
+				return culvert, i, errors.Wrap(err, 0) 
 			}
 			culvert.Conduits = append(culvert.Conduits, conduit)
 			culvert.NumConduits++
@@ -332,7 +332,7 @@ func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, in
 		case strings.HasPrefix(line, "Multiple Barrel Culv="):
 			conduit, err := getConduits(line, false)
 			if err != nil {
-				return culvert, i, errors.Wrap(err, 1) 
+				return culvert, i, errors.Wrap(err, 0) 
 			}
 			culvert.Conduits = append(culvert.Conduits, conduit)
 			culvert.NumConduits++
@@ -352,7 +352,7 @@ func getBridgeData(hsSc *bufio.Scanner, i int, lineData []string) (bridges, int,
 
 	station, err := parseFloat(strings.TrimSpace(lineData[1]), 64)
 	if err != nil {
-		return bridge, i, errors.Wrap(err, 1) 
+		return bridge, i, errors.Wrap(err, 0) 
 	}
 	bridge.Station = station
 
@@ -364,7 +364,7 @@ func getBridgeData(hsSc *bufio.Scanner, i int, lineData []string) (bridges, int,
 			var description string
 			description, i, err = getDescription(hsSc, i, "END DESCRIPTION:")
 			if err != nil {
-				return bridge, i, errors.Wrap(err, 1) 
+				return bridge, i, errors.Wrap(err, 0) 
 			}
 			bridge.Description += description
 
@@ -377,14 +377,14 @@ func getBridgeData(hsSc *bufio.Scanner, i int, lineData []string) (bridges, int,
 			nextLineData := strings.Split(hsSc.Text(), ",")
 			deckWidth, err := parseFloat(strings.TrimSpace(nextLineData[0]), 64)
 			if err != nil {
-				return bridge, i, errors.Wrap(err, 1) 
+				return bridge, i, errors.Wrap(err, 0) 
 			}
 			bridge.DeckWidth = deckWidth
 
 			var upHighLowPair [2]maxMinPairs
 			upHighLowPair, i, err = getHighLowChord(hsSc, i, nextLineData[4], 80, 8)
 			if err != nil {
-				return bridge, i, errors.Wrap(err, 1) 
+				return bridge, i, errors.Wrap(err, 0) 
 			}
 			bridge.UpHighChord = upHighLowPair[0]
 			bridge.UpLowChord = upHighLowPair[1]
@@ -392,7 +392,7 @@ func getBridgeData(hsSc *bufio.Scanner, i int, lineData []string) (bridges, int,
 			var downHighLowPair [2]maxMinPairs
 			downHighLowPair, i, err = getHighLowChord(hsSc, i, nextLineData[5], 80, 8)
 			if err != nil {
-				return bridge, i, errors.Wrap(err, 1) 
+				return bridge, i, errors.Wrap(err, 0) 
 			}
 			bridge.DownHighChord = downHighLowPair[0]
 			bridge.DownLowChord = downHighLowPair[1]
@@ -419,21 +419,21 @@ func getGates(nextLine string) (gates, error) {
 
 	width, err := stringtoFloat(nextLineData[1])
 	if err != nil {
-		return gate, errors.Wrap(err, 1) 
+		return gate, errors.Wrap(err, 0) 
 
 	}
 	gate.Width = width
 
 	height, err := stringtoFloat(nextLineData[2])
 	if err != nil {
-		return gate, errors.Wrap(err, 1) 
+		return gate, errors.Wrap(err, 0) 
 
 	}
 	gate.Height = height
 
 	numopenings, err := strconv.Atoi(strings.TrimSpace(nextLineData[13]))
 	if err != nil {
-		return gate, errors.Wrap(err, 1) 
+		return gate, errors.Wrap(err, 0) 
 
 	}
 	gate.NumOpenings = numopenings
@@ -446,7 +446,7 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 
 	f, err := rm.FileStore.GetObject(fn)
 	if err != nil {
-		return weir, errors.Wrap(err, 1) 
+		return weir, errors.Wrap(err, 0) 
 
 	}
 	defer f.Close()
@@ -460,7 +460,7 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 			lineData := strings.Split(rightofEquals(wSc.Text()), ",")
 			station, err := parseFloat(strings.TrimSpace(lineData[1]), 64)
 			if err != nil {
-				return weir, errors.Wrap(err, 1) 
+				return weir, errors.Wrap(err, 0) 
 
 			}
 			weir.Station = station
@@ -470,7 +470,7 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 			case strings.HasPrefix(line, "BEGIN DESCRIPTION"):
 				description, _, err := getDescription(wSc, 0, "END DESCRIPTION:")
 				if err != nil {
-					return weir, errors.Wrap(err, 1) 
+					return weir, errors.Wrap(err, 0) 
 
 				}
 				weir.Description += description
@@ -481,14 +481,14 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 			case strings.HasPrefix(line, "#Inline Weir SE="):
 				nElev, err := strconv.Atoi(strings.TrimSpace(rightofEquals(line)))
 				if err != nil {
-					return weir, errors.Wrap(err, 1) 
+					return weir, errors.Wrap(err, 0) 
 
 				}
 				nLines := numberofLines(nElev*2, 80, 8)
 
 				elev, _, err := getMaxMinElev(wSc, 0, nLines, 0, 80, 8, 2)
 				if err != nil {
-					return weir, errors.Wrap(err, 1) 
+					return weir, errors.Wrap(err, 0) 
 
 				}
 				weir.WeirElev = elev
@@ -498,7 +498,7 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 				nextLineData := strings.Split(wSc.Text(), ",")
 				weirWidth, err := parseFloat(strings.TrimSpace(nextLineData[1]), 64)
 				if err != nil {
-					return weir, errors.Wrap(err, 1) 
+					return weir, errors.Wrap(err, 0) 
 
 				}
 				weir.WeirWidth = weirWidth
@@ -507,7 +507,7 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 				wSc.Scan()
 				gate, err := getGates(wSc.Text())
 				if err != nil {
-					return weir, errors.Wrap(err, 1) 
+					return weir, errors.Wrap(err, 0) 
 
 				}
 				weir.Gates = append(weir.Gates, gate)
@@ -516,7 +516,7 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 			case strings.HasPrefix(line, "IW Culv="):
 				conduit, err := getConduits(line, false)
 				if err != nil {
-					return weir, errors.Wrap(err, 1) 
+					return weir, errors.Wrap(err, 0) 
 
 				}
 				weir.Conduits = append(weir.Conduits, conduit)
@@ -541,7 +541,7 @@ func getHydraulicStructureData(rm *RasModel, fn string, idx int) (hydraulicStruc
 
 	f, err := rm.FileStore.GetObject(fn)
 	if err != nil {
-		return structures, errors.Wrap(err, 1) 
+		return structures, errors.Wrap(err, 0) 
 
 	}
 	defer f.Close()
@@ -561,7 +561,7 @@ func getHydraulicStructureData(rm *RasModel, fn string, idx int) (hydraulicStruc
 				data := strings.Split(rightofEquals(line), ",")
 				structureType, err := strconv.Atoi(strings.TrimSpace(data[0]))
 				if err != nil {
-					return structures, errors.Wrap(err, 1) 
+					return structures, errors.Wrap(err, 0) 
 
 				}
 				switch structureType {
@@ -572,7 +572,7 @@ func getHydraulicStructureData(rm *RasModel, fn string, idx int) (hydraulicStruc
 					var culvert culverts
 					culvert, i, err = getCulvertData(hsSc, i, data)
 					if err != nil {
-						return structures, errors.Wrap(err, 1) 
+						return structures, errors.Wrap(err, 0) 
 
 					}
 					cData.Culverts = append(cData.Culverts, culvert)
@@ -582,7 +582,7 @@ func getHydraulicStructureData(rm *RasModel, fn string, idx int) (hydraulicStruc
 					var bridge bridges
 					bridge, i, err = getBridgeData(hsSc, i, data)
 					if err != nil {
-						return structures, errors.Wrap(err, 1) 
+						return structures, errors.Wrap(err, 0) 
 
 					}
 					bData.Bridges = append(bData.Bridges, bridge)
@@ -591,7 +591,7 @@ func getHydraulicStructureData(rm *RasModel, fn string, idx int) (hydraulicStruc
 				case 5:
 					weir, err := getWeirData(rm, fn, i)
 					if err != nil {
-						return structures, errors.Wrap(err, 1) 
+						return structures, errors.Wrap(err, 0) 
 
 					}
 					wData.Weirs = append(wData.Weirs, weir)

--- a/tools/structures.go
+++ b/tools/structures.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"strconv"
 	"strings"
+
+	"github.com/go-errors/errors" // warning: replaces standard errors
 )
 
 var conduitShapes map[int]string = map[int]string{
@@ -123,7 +125,7 @@ out:
 					if nvalues%interval == 0 {
 						val, err := parseFloat(sVal, 64)
 						if err != nil {
-							return values, i, err
+							return values, i, errors.Wrap(err, 1) 
 						}
 						values = append(values, val)
 					}
@@ -150,7 +152,7 @@ func getMaxMinElev(hsSc *bufio.Scanner, i int, nLines int, nSkipLines int, colWi
 	elevations, i, err := datafromTextBlock(hsSc, i, nLines, nSkipLines, colWidth, valueWidth, interval)
 
 	if err != nil {
-		return pair, i, err
+		return pair, i, errors.Wrap(err, 1) 
 	}
 
 	if len(elevations) == 0 {
@@ -159,12 +161,12 @@ func getMaxMinElev(hsSc *bufio.Scanner, i int, nLines int, nSkipLines int, colWi
 
 	maxElev, err := maxValue(elevations)
 	if err != nil {
-		return pair, i, err
+		return pair, i, errors.Wrap(err, 1) 
 	}
 
 	minElev, err := minValue(elevations)
 	if err != nil {
-		return pair, i, err
+		return pair, i, errors.Wrap(err, 1) 
 	}
 
 	pair = maxMinPairs{Max: maxElev, Min: minElev}
@@ -181,20 +183,20 @@ func getHighLowChord(hsSc *bufio.Scanner, i int, nElevText string, colWidth int,
 
 	nElev, err := strconv.Atoi(strings.TrimSpace(nElevText))
 	if err != nil {
-		return highLowPairs, i, err
+		return highLowPairs, i, errors.Wrap(err, 1) 
 	}
 
 	nLines := numberofLines(nElev, 80, 8)
 
 	highPair, i, err := getMaxMinElev(hsSc, i, nLines, nLines, 80, 8, 1)
 	if err != nil {
-		return highLowPairs, i, err
+		return highLowPairs, i, errors.Wrap(err, 1) 
 	}
 	highLowPairs[0] = highPair
 
 	lowPair, i, err := getMaxMinElev(hsSc, i, nLines, 0, 80, 8, 1)
 	if err != nil {
-		return highLowPairs, i, err
+		return highLowPairs, i, errors.Wrap(err, 1) 
 	}
 	highLowPairs[1] = lowPair
 
@@ -206,7 +208,7 @@ func stringtoFloat(s string) (float64, error) {
 	if trimmed != "" {
 		val, err := parseFloat(trimmed, 64)
 		if err != nil {
-			return 0, err
+			return 0, errors.Wrap(err, 1)
 		}
 		return val, nil
 	}
@@ -224,7 +226,8 @@ func getConduits(line string, single bool) (conduits, error) {
 	} else {
 		numbarrels, err := strconv.Atoi(strings.TrimSpace(lineData[11]))
 		if err != nil {
-			return conduit, err
+			return conduit, errors.Wrap(err, 1) 
+
 		}
 		conduit.NumBarrels = numbarrels
 		conduit.Name = strings.TrimSpace(lineData[12])
@@ -232,31 +235,36 @@ func getConduits(line string, single bool) (conduits, error) {
 
 	shapeID, err := strconv.Atoi(strings.TrimSpace(lineData[0]))
 	if err != nil {
-		return conduit, err
+		return conduit, errors.Wrap(err, 1) 
+
 	}
 	conduit.Shape = conduitShapes[shapeID]
 
 	rise, err := stringtoFloat(lineData[1])
 	if err != nil {
-		return conduit, err
+		return conduit, errors.Wrap(err, 1) 
+
 	}
 	conduit.Rise = rise
 
 	span, err := stringtoFloat(lineData[2])
 	if err != nil {
-		return conduit, err
+		return conduit, errors.Wrap(err, 1) 
+
 	}
 	conduit.Span = span
 
 	length, err := stringtoFloat(lineData[3])
 	if err != nil {
-		return conduit, err
+		return conduit, errors.Wrap(err, 1) 
+
 	}
 	conduit.Length = length
 
 	mannings, err := stringtoFloat(lineData[4])
 	if err != nil {
-		return conduit, err
+		return conduit, errors.Wrap(err, 1) 
+
 	}
 	conduit.ManningsN = mannings
 
@@ -268,7 +276,7 @@ func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, in
 
 	station, err := parseFloat(strings.TrimSpace(lineData[1]), 64)
 	if err != nil {
-		return culvert, i, err
+		return culvert, i, errors.Wrap(err, 1) 
 	}
 	culvert.Station = station
 
@@ -280,7 +288,7 @@ func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, in
 			var description string
 			description, i, err = getDescription(hsSc, i, "END DESCRIPTION:")
 			if err != nil {
-				return culvert, i, err
+				return culvert, i, errors.Wrap(err, 1) 
 			}
 			culvert.Description += description
 
@@ -293,14 +301,14 @@ func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, in
 			nextLineData := strings.Split(hsSc.Text(), ",")
 			deckWidth, err := parseFloat(strings.TrimSpace(nextLineData[0]), 64)
 			if err != nil {
-				return culvert, i, err
+				return culvert, i, errors.Wrap(err, 1) 
 			}
 			culvert.DeckWidth = deckWidth
 
 			var upHighLowPair [2]maxMinPairs
 			upHighLowPair, i, err = getHighLowChord(hsSc, i, nextLineData[4], 80, 8)
 			if err != nil {
-				return culvert, i, err
+				return culvert, i, errors.Wrap(err, 1) 
 			}
 			culvert.UpHighChord = upHighLowPair[0]
 			culvert.UpLowChord = upHighLowPair[1]
@@ -308,7 +316,7 @@ func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, in
 			var downHighLowPair [2]maxMinPairs
 			downHighLowPair, i, err = getHighLowChord(hsSc, i, nextLineData[5], 80, 8)
 			if err != nil {
-				return culvert, i, err
+				return culvert, i, errors.Wrap(err, 1) 
 			}
 			culvert.DownHighChord = downHighLowPair[0]
 			culvert.DownLowChord = downHighLowPair[1]
@@ -316,7 +324,7 @@ func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, in
 		case strings.HasPrefix(line, "Culvert="):
 			conduit, err := getConduits(line, true)
 			if err != nil {
-				return culvert, i, err
+				return culvert, i, errors.Wrap(err, 1) 
 			}
 			culvert.Conduits = append(culvert.Conduits, conduit)
 			culvert.NumConduits++
@@ -324,7 +332,7 @@ func getCulvertData(hsSc *bufio.Scanner, i int, lineData []string) (culverts, in
 		case strings.HasPrefix(line, "Multiple Barrel Culv="):
 			conduit, err := getConduits(line, false)
 			if err != nil {
-				return culvert, i, err
+				return culvert, i, errors.Wrap(err, 1) 
 			}
 			culvert.Conduits = append(culvert.Conduits, conduit)
 			culvert.NumConduits++
@@ -344,7 +352,7 @@ func getBridgeData(hsSc *bufio.Scanner, i int, lineData []string) (bridges, int,
 
 	station, err := parseFloat(strings.TrimSpace(lineData[1]), 64)
 	if err != nil {
-		return bridge, i, err
+		return bridge, i, errors.Wrap(err, 1) 
 	}
 	bridge.Station = station
 
@@ -356,7 +364,7 @@ func getBridgeData(hsSc *bufio.Scanner, i int, lineData []string) (bridges, int,
 			var description string
 			description, i, err = getDescription(hsSc, i, "END DESCRIPTION:")
 			if err != nil {
-				return bridge, i, err
+				return bridge, i, errors.Wrap(err, 1) 
 			}
 			bridge.Description += description
 
@@ -369,14 +377,14 @@ func getBridgeData(hsSc *bufio.Scanner, i int, lineData []string) (bridges, int,
 			nextLineData := strings.Split(hsSc.Text(), ",")
 			deckWidth, err := parseFloat(strings.TrimSpace(nextLineData[0]), 64)
 			if err != nil {
-				return bridge, i, err
+				return bridge, i, errors.Wrap(err, 1) 
 			}
 			bridge.DeckWidth = deckWidth
 
 			var upHighLowPair [2]maxMinPairs
 			upHighLowPair, i, err = getHighLowChord(hsSc, i, nextLineData[4], 80, 8)
 			if err != nil {
-				return bridge, i, err
+				return bridge, i, errors.Wrap(err, 1) 
 			}
 			bridge.UpHighChord = upHighLowPair[0]
 			bridge.UpLowChord = upHighLowPair[1]
@@ -384,7 +392,7 @@ func getBridgeData(hsSc *bufio.Scanner, i int, lineData []string) (bridges, int,
 			var downHighLowPair [2]maxMinPairs
 			downHighLowPair, i, err = getHighLowChord(hsSc, i, nextLineData[5], 80, 8)
 			if err != nil {
-				return bridge, i, err
+				return bridge, i, errors.Wrap(err, 1) 
 			}
 			bridge.DownHighChord = downHighLowPair[0]
 			bridge.DownLowChord = downHighLowPair[1]
@@ -411,19 +419,22 @@ func getGates(nextLine string) (gates, error) {
 
 	width, err := stringtoFloat(nextLineData[1])
 	if err != nil {
-		return gate, err
+		return gate, errors.Wrap(err, 1) 
+
 	}
 	gate.Width = width
 
 	height, err := stringtoFloat(nextLineData[2])
 	if err != nil {
-		return gate, err
+		return gate, errors.Wrap(err, 1) 
+
 	}
 	gate.Height = height
 
 	numopenings, err := strconv.Atoi(strings.TrimSpace(nextLineData[13]))
 	if err != nil {
-		return gate, err
+		return gate, errors.Wrap(err, 1) 
+
 	}
 	gate.NumOpenings = numopenings
 
@@ -435,7 +446,8 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 
 	f, err := rm.FileStore.GetObject(fn)
 	if err != nil {
-		return weir, err
+		return weir, errors.Wrap(err, 1) 
+
 	}
 	defer f.Close()
 
@@ -448,7 +460,8 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 			lineData := strings.Split(rightofEquals(wSc.Text()), ",")
 			station, err := parseFloat(strings.TrimSpace(lineData[1]), 64)
 			if err != nil {
-				return weir, err
+				return weir, errors.Wrap(err, 1) 
+
 			}
 			weir.Station = station
 		} else if wi > i {
@@ -457,7 +470,8 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 			case strings.HasPrefix(line, "BEGIN DESCRIPTION"):
 				description, _, err := getDescription(wSc, 0, "END DESCRIPTION:")
 				if err != nil {
-					return weir, err
+					return weir, errors.Wrap(err, 1) 
+
 				}
 				weir.Description += description
 
@@ -467,13 +481,15 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 			case strings.HasPrefix(line, "#Inline Weir SE="):
 				nElev, err := strconv.Atoi(strings.TrimSpace(rightofEquals(line)))
 				if err != nil {
-					return weir, err
+					return weir, errors.Wrap(err, 1) 
+
 				}
 				nLines := numberofLines(nElev*2, 80, 8)
 
 				elev, _, err := getMaxMinElev(wSc, 0, nLines, 0, 80, 8, 2)
 				if err != nil {
-					return weir, err
+					return weir, errors.Wrap(err, 1) 
+
 				}
 				weir.WeirElev = elev
 
@@ -482,7 +498,8 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 				nextLineData := strings.Split(wSc.Text(), ",")
 				weirWidth, err := parseFloat(strings.TrimSpace(nextLineData[1]), 64)
 				if err != nil {
-					return weir, err
+					return weir, errors.Wrap(err, 1) 
+
 				}
 				weir.WeirWidth = weirWidth
 
@@ -490,7 +507,8 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 				wSc.Scan()
 				gate, err := getGates(wSc.Text())
 				if err != nil {
-					return weir, err
+					return weir, errors.Wrap(err, 1) 
+
 				}
 				weir.Gates = append(weir.Gates, gate)
 				weir.NumGates++
@@ -498,7 +516,8 @@ func getWeirData(rm *RasModel, fn string, i int) (weirs, error) {
 			case strings.HasPrefix(line, "IW Culv="):
 				conduit, err := getConduits(line, false)
 				if err != nil {
-					return weir, err
+					return weir, errors.Wrap(err, 1) 
+
 				}
 				weir.Conduits = append(weir.Conduits, conduit)
 				weir.NumConduits++
@@ -522,7 +541,8 @@ func getHydraulicStructureData(rm *RasModel, fn string, idx int) (hydraulicStruc
 
 	f, err := rm.FileStore.GetObject(fn)
 	if err != nil {
-		return structures, err
+		return structures, errors.Wrap(err, 1) 
+
 	}
 	defer f.Close()
 
@@ -541,7 +561,8 @@ func getHydraulicStructureData(rm *RasModel, fn string, idx int) (hydraulicStruc
 				data := strings.Split(rightofEquals(line), ",")
 				structureType, err := strconv.Atoi(strings.TrimSpace(data[0]))
 				if err != nil {
-					return structures, err
+					return structures, errors.Wrap(err, 1) 
+
 				}
 				switch structureType {
 				case 1:
@@ -551,7 +572,8 @@ func getHydraulicStructureData(rm *RasModel, fn string, idx int) (hydraulicStruc
 					var culvert culverts
 					culvert, i, err = getCulvertData(hsSc, i, data)
 					if err != nil {
-						return structures, err
+						return structures, errors.Wrap(err, 1) 
+
 					}
 					cData.Culverts = append(cData.Culverts, culvert)
 					cData.NumCulverts++
@@ -560,7 +582,8 @@ func getHydraulicStructureData(rm *RasModel, fn string, idx int) (hydraulicStruc
 					var bridge bridges
 					bridge, i, err = getBridgeData(hsSc, i, data)
 					if err != nil {
-						return structures, err
+						return structures, errors.Wrap(err, 1) 
+
 					}
 					bData.Bridges = append(bData.Bridges, bridge)
 					bData.NumBridges++
@@ -568,7 +591,8 @@ func getHydraulicStructureData(rm *RasModel, fn string, idx int) (hydraulicStruc
 				case 5:
 					weir, err := getWeirData(rm, fn, i)
 					if err != nil {
-						return structures, err
+						return structures, errors.Wrap(err, 1) 
+
 					}
 					wData.Weirs = append(wData.Weirs, weir)
 					wData.NumWeirs++

--- a/tools/utils.go
+++ b/tools/utils.go
@@ -2,9 +2,10 @@ package tools
 
 import (
 	"bufio"
-	"errors"
 	"strconv"
 	"strings"
+
+	"github.com/go-errors/errors" // warning: replaces standard errors
 )
 
 func maxValue(values []float64) (float64, error) {


### PR DESCRIPTION
This PR:

- Wraps errors using a third-party library to store stack trace as well.
- Returns stack trace in a simple response

The standard runtime/debug was only showing stack trace for the current file