### PR TITLE
Feature/simplify endpoints

### DIFF
--- a/handlers/geospatialdata.go
+++ b/handlers/geospatialdata.go
@@ -1,13 +1,17 @@
 package handlers
 
 import (
+	"bufio"
 	"fmt"
 	"net/http"
+	"path/filepath"
+	"strings"
 
 	"app/config"
+	"app/tools"
 
-	ras "app/tools"
-
+	"github.com/USACE/filestore"
+	"github.com/dewberry/gdal"
 	"github.com/go-errors/errors" // warning: replaces standard errors
 	"github.com/labstack/echo/v4"
 )
@@ -30,16 +34,68 @@ func GeospatialData(ac *config.APIConfig) echo.HandlerFunc {
 			return c.JSON(http.StatusBadRequest, "Missing query parameter: `definition_file`")
 		}
 
-		rm, err := ras.NewRasModel(definitionFile, *ac.FileStore)
-		if err != nil {
-			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, fmt.Sprintf("Go error encountered: %v", err.Error()), err.(*errors.Error).ErrorStack()})
+		if !isAModel(ac.FileStore, definitionFile) {
+			return c.JSON(http.StatusBadRequest, definitionFile+" is not a valid RAS prj file.")
 		}
 
-		data, err := rm.GeospatialData(ac.DestinationCRS)
+		if !isGeospatial(definitionFile, *ac.FileStore) {
+			return c.JSON(http.StatusBadRequest, definitionFile+" is not geospatial.")
+		}
+
+		data, err := geospatialData(definitionFile, ac.FileStore, ac.DestinationCRS)
 		if err != nil {
 			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, fmt.Sprintf("Go error encountered: %v", err.Error()), err.(*errors.Error).ErrorStack()})
 		}
 
 		return c.JSON(http.StatusOK, data)
 	}
+}
+
+func geospatialData(definitionFile string, fs *filestore.FileStore, destinationCRS int) (tools.GeoData, error) {
+	gd := tools.GeoData{Features: make(map[string]tools.Features)}
+
+	mfiles, err := modFiles(definitionFile, *fs)
+	if err != nil {
+		return gd, errors.Wrap(err, 0)
+	}
+
+	projecFile := strings.TrimSuffix(definitionFile, ".prj") + ".projection"
+	proj, err := getProjection(*fs, projecFile)
+	if err != nil {
+		return gd, errors.Wrap(err, 0)
+	}
+
+	for _, fp := range mfiles {
+
+		ext := filepath.Ext(fp)
+
+		switch {
+
+		case tools.RasRE.Geom.MatchString(ext):
+
+			if err := tools.GetGeospatialData(&gd, *fs, fp, proj, destinationCRS); err != nil {
+				return gd, errors.Wrap(err, 0)
+			}
+
+		}
+	}
+
+	return gd, nil
+}
+
+func getProjection(fs filestore.FileStore, fn string) (string, error) {
+
+	f, err := fs.GetObject(fn)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	sc.Scan()
+	line := sc.Text()
+
+	sourceSpRef := gdal.CreateSpatialReference(line)
+
+	return line, sourceSpRef.Validate()
 }

--- a/handlers/geospatialdata.go
+++ b/handlers/geospatialdata.go
@@ -52,7 +52,7 @@ func GeospatialData(ac *config.APIConfig) echo.HandlerFunc {
 }
 
 func geospatialData(definitionFile string, fs *filestore.FileStore, destinationCRS int) (tools.GeoData, error) {
-	gd := tools.GeoData{Features: make(map[string]tools.Features)}
+	gd := tools.GeoData{Features: make(map[string]tools.Features), Georeference: destinationCRS}
 
 	mfiles, err := modFiles(definitionFile, *fs)
 	if err != nil {

--- a/handlers/isamodel.go
+++ b/handlers/isamodel.go
@@ -28,18 +28,23 @@ func IsAModel(fs *filestore.FileStore) echo.HandlerFunc {
 			return c.JSON(http.StatusBadRequest, "Missing query parameter: `definition_file`")
 		}
 
-		if filepath.Ext(definitionFile) != ".prj" {
-			return c.JSON(http.StatusOK, false)
-		}
-
-		firstLine, err := tools.ReadFirstLine(*fs, definitionFile)
-		if err != nil {
-			return c.JSON(http.StatusOK, false)
-		}
-		if !strings.Contains(firstLine, "Proj Title=") {
-			return c.JSON(http.StatusOK, false)
-		}
-
-		return c.JSON(http.StatusOK, true)
+		return c.JSON(http.StatusOK, isAModel(fs, definitionFile))
 	}
+}
+
+func isAModel(fs *filestore.FileStore, definitionFile string) bool {
+	if filepath.Ext(definitionFile) != ".prj" {
+		return false
+	}
+
+	firstLine, err := tools.ReadFirstLine(*fs, definitionFile)
+	if err != nil {
+		return false
+	}
+
+	if !strings.Contains(firstLine, "Proj Title=") {
+		return false
+	}
+
+	return true
 }

--- a/handlers/isamodel.go
+++ b/handlers/isamodel.go
@@ -46,5 +46,16 @@ func isAModel(fs *filestore.FileStore, definitionFile string) bool {
 		return false
 	}
 
-	return true
+	files, err := modFiles(definitionFile, fs)
+	if err != nil {
+		return false
+	}
+
+	for _, f := range files {
+		if filepath.Ext(f)[0:2] == ".g" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/handlers/isamodel.go
+++ b/handlers/isamodel.go
@@ -2,8 +2,10 @@ package handlers
 
 import (
 	"net/http"
+	"path/filepath"
+	"strings"
 
-	ras "app/tools"
+	"app/tools"
 
 	"github.com/USACE/filestore"
 	"github.com/labstack/echo/v4"
@@ -26,12 +28,18 @@ func IsAModel(fs *filestore.FileStore) echo.HandlerFunc {
 			return c.JSON(http.StatusBadRequest, "Missing query parameter: `definition_file`")
 		}
 
-		rm, err := ras.NewRasModel(definitionFile, *fs)
+		if filepath.Ext(definitionFile) != ".prj" {
+			return c.JSON(http.StatusOK, false)
+		}
+
+		firstLine, err := tools.ReadFirstLine(*fs, definitionFile)
 		if err != nil {
 			return c.JSON(http.StatusOK, false)
 		}
-		isIt := rm.IsAModel()
+		if !strings.Contains(firstLine, "Proj Title=") {
+			return c.JSON(http.StatusOK, false)
+		}
 
-		return c.JSON(http.StatusOK, isIt)
+		return c.JSON(http.StatusOK, true)
 	}
 }

--- a/handlers/isamodel.go
+++ b/handlers/isamodel.go
@@ -46,7 +46,7 @@ func isAModel(fs *filestore.FileStore, definitionFile string) bool {
 		return false
 	}
 
-	files, err := modFiles(definitionFile, fs)
+	files, err := modFiles(definitionFile, *fs)
 	if err != nil {
 		return false
 	}

--- a/handlers/modeltype.go
+++ b/handlers/modeltype.go
@@ -1,13 +1,9 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 
-	ras "app/tools"
-
-	"github.com/USACE/filestore"
-	"github.com/go-errors/errors" // warning: replaces standard errors
+	"github.com/USACE/filestore" // warning: replaces standard errors
 	"github.com/labstack/echo/v4"
 )
 
@@ -29,12 +25,10 @@ func ModelType(fs *filestore.FileStore) echo.HandlerFunc {
 			return c.JSON(http.StatusBadRequest, "Missing query parameter: `definition_file`")
 		}
 
-		rm, err := ras.NewRasModel(definitionFile, *fs)
-		if err != nil {
-			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, fmt.Sprintf("Go error encountered: %v", err.Error()), err.(*errors.Error).ErrorStack()})
+		if !isAModel(fs, definitionFile) {
+			return c.JSON(http.StatusBadRequest, definitionFile+" is not a valid RAS prj file.")
 		}
-		typ := rm.ModelType()
 
-		return c.JSON(http.StatusOK, typ)
+		return c.JSON(http.StatusOK, "RAS")
 	}
 }

--- a/handlers/modelversion.go
+++ b/handlers/modelversion.go
@@ -1,13 +1,15 @@
 package handlers
 
 import (
+	"app/tools"
+	"bufio"
 	"fmt"
 	"net/http"
+	"path/filepath"
+	"regexp"
+	"strings"
 
-	ras "app/tools"
-
-	"github.com/USACE/filestore"
-	"github.com/go-errors/errors" // warning: replaces standard errors
+	"github.com/USACE/filestore" // warning: replaces standard errors
 	"github.com/labstack/echo/v4"
 )
 
@@ -29,12 +31,92 @@ func ModelVersion(fs *filestore.FileStore) echo.HandlerFunc {
 			return c.JSON(http.StatusBadRequest, "Missing query parameter: `definition_file`")
 		}
 
-		rm, err := ras.NewRasModel(definitionFile, *fs)
-		if err != nil {
-			return c.JSON(http.StatusInternalServerError, SimpleResponse{http.StatusInternalServerError, fmt.Sprintf("Go error encountered: %v", err.Error()), err.(*errors.Error).ErrorStack()})
+		if !isAModel(fs, definitionFile) {
+			return c.JSON(http.StatusBadRequest, definitionFile+" is not a valid RAS prj file.")
 		}
-		vers := rm.ModelVersion()
 
-		return c.JSON(http.StatusOK, vers)
+		version, err := getVersions(definitionFile, *fs)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, err.Error())
+		}
+
+		return c.JSON(http.StatusOK, version)
 	}
+}
+
+func modFiles(definitionFile string, fs filestore.FileStore) ([]string, error) {
+	mFiles := make([]string, 0)
+	prefix := filepath.Dir(definitionFile) + "/"
+
+	files, err := fs.GetDir(prefix, false)
+	if err != nil {
+		return mFiles, err
+	}
+
+	for _, file := range *files {
+		// get only files that share the same base name or .prj files for projection
+		// rational behind .prj file is that there can be a shp file in the same level of Hec-RAS
+		// providing potential projection
+		if strings.HasPrefix(filepath.Join(file.Path, file.Name), strings.TrimSuffix(definitionFile, "prj")) || filepath.Ext(file.Name) == ".prj" {
+			mFiles = append(mFiles, filepath.Join(file.Path, file.Name))
+		}
+	}
+
+	return mFiles, nil
+}
+
+func pullVersion(fp string, fs filestore.FileStore) (string, error) {
+	f, err := fs.GetObject(fp)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	var line string
+	for sc.Scan() {
+
+		line = sc.Text()
+
+		match, err := regexp.MatchString("Program Version=", line)
+		if err != nil {
+			return "", err
+		}
+
+		if match {
+			return strings.Split(line, "=")[1], nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to find program version in file %s", fp)
+}
+
+func getVersions(definitionFile string, fs filestore.FileStore) (string, error) {
+	var version string
+
+	mFiles, err := modFiles(definitionFile, fs)
+	if err != nil {
+		return version, err
+	}
+
+	for _, fp := range mFiles {
+
+		ext := filepath.Ext(fp)
+
+		if tools.RasRE.Plan.MatchString(ext) ||
+			tools.RasRE.Geom.MatchString(ext) ||
+			tools.RasRE.AllFlow.MatchString(ext) {
+			ver, err := pullVersion(fp, fs)
+			if err != nil {
+				return version, err
+			}
+			version += fmt.Sprintf("%s: %s, ", ext, ver)
+		}
+	}
+
+	if len(version) >= 2 {
+		version = version[0 : len(version)-2]
+	}
+
+	return version, nil
 }

--- a/handlers/ping.go
+++ b/handlers/ping.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/USACE/filestore"
@@ -9,9 +8,9 @@ import (
 )
 
 type SimpleResponse struct {
-	Status  	 int
-	Message 	 string
-	StackTrace   string
+	Status     int
+	Message    string
+	StackTrace string
 }
 
 // Ping godoc
@@ -26,7 +25,7 @@ func Ping(fs *filestore.FileStore) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		switch (*fs).(type) {
 		case *filestore.BlockFS:
-			fmt.Println("File is local")
+			// fmt.Println("File is local")
 			return c.JSON(http.StatusOK, map[string]string{"status": "available"})
 
 		case *filestore.S3FS:
@@ -35,7 +34,7 @@ func Ping(fs *filestore.FileStore) echo.HandlerFunc {
 			if err != nil {
 				return c.JSON(http.StatusInternalServerError, map[string]string{"status": "unavailable"})
 			}
-			fmt.Println("File is on S3")
+			// fmt.Println("File is on S3")
 			return c.JSON(http.StatusOK, map[string]string{"status": "available"})
 		}
 		return c.JSON(http.StatusInternalServerError, map[string]string{"status": "unavailable"})

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func main() {
 	e := echo.New()
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
+	e.Use(middleware.Gzip())
 
 	// HealthCheck
 	e.GET("/ping", handlers.Ping(appConfig.FileStore))

--- a/tools/areas.go
+++ b/tools/areas.go
@@ -9,12 +9,12 @@ import (
 	"github.com/go-errors/errors" // warning: replaces standard errors
 )
 
-type storageArea struct {
+type StorageArea struct {
 	NumBCLines int      `json:"Num BC Lines"`
 	BCLines    []string `json:"BC Lines"`
 }
 
-type twoDArea struct {
+type TwoDArea struct {
 	NumCells   int      `json:"Num Mesh Cells"`
 	NumBCLines int      `json:"Num BC Lines"`
 	BCLines    []string `json:"BC Lines"`
@@ -67,10 +67,10 @@ areaLoop:
 		}
 	}
 	if is2D == "0" {
-		area := storageArea{}
+		area := StorageArea{}
 		return name, area, nil
 	} else {
-		area := twoDArea{
+		area := TwoDArea{
 			NumCells: numCells,
 		}
 		return name, area, nil

--- a/tools/connections.go
+++ b/tools/connections.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Store HEC-RAS SA/2D Area Connections
-type connection struct {
+type Connection struct {
 	Description string      `json:"Description"`
 	UpSA        string      `json:"Up Area"`
 	DnSA        string      `json:"Dn Area"`
@@ -22,9 +22,9 @@ type connection struct {
 }
 
 // Extract data from Connections
-func getConnectionsData(rm *RasModel, fn string, i int) (string, connection, error) {
+func getConnectionsData(rm *RasModel, fn string, i int) (string, Connection, error) {
 	var name string
-	var connection connection
+	var connection Connection
 
 	f, err := rm.FileStore.GetObject(fn)
 	if err != nil {

--- a/tools/geom.go
+++ b/tools/geom.go
@@ -17,9 +17,9 @@ type GeomFileContents struct {
 	ProgramVersion string                 `json:"Program Version"`
 	Description    string                 `json:"Description"`
 	Structures     []hydraulicStructures  `json:"Hydraulic Structures"`
-	StorageAreas   map[string]storageArea `json:"Storage Areas"`
-	TwoDAreas      map[string]twoDArea    `json:"2D Areas"`
-	Connections    map[string]connection  `json:"Connections"`
+	StorageAreas   map[string]StorageArea `json:"Storage Areas"`
+	TwoDAreas      map[string]TwoDArea    `json:"2D Areas"`
+	Connections    map[string]Connection  `json:"Connections"`
 	Notes          string
 }
 
@@ -31,9 +31,9 @@ func getGeomData(rm *RasModel, fn string, wg *sync.WaitGroup) {
 	meta := GeomFileContents{
 		Path:         fn,
 		FileExt:      filepath.Ext(fn),
-		StorageAreas: make(map[string]storageArea),
-		TwoDAreas:    make(map[string]twoDArea),
-		Connections:  make(map[string]connection),
+		StorageAreas: make(map[string]StorageArea),
+		TwoDAreas:    make(map[string]TwoDArea),
+		Connections:  make(map[string]Connection),
 	}
 
 	var err error
@@ -95,11 +95,11 @@ func getGeomData(rm *RasModel, fn string, wg *sync.WaitGroup) {
 			}
 			switch areaData.(type) {
 
-			case storageArea:
-				meta.StorageAreas[areaName] = areaData.(storageArea)
+			case StorageArea:
+				meta.StorageAreas[areaName] = areaData.(StorageArea)
 
-			case twoDArea:
-				meta.TwoDAreas[areaName] = areaData.(twoDArea)
+			case TwoDArea:
+				meta.TwoDAreas[areaName] = areaData.(TwoDArea)
 			}
 			header = false
 

--- a/tools/model.go
+++ b/tools/model.go
@@ -27,7 +27,7 @@ type fileExtMatchers struct {
 	Projection  *regexp.Regexp
 }
 
-var rasRE fileExtMatchers = fileExtMatchers{ // Maybe these ones are better? need a regex experts opinion
+var RasRE fileExtMatchers = fileExtMatchers{ // Maybe these ones are better? need a regex experts opinion
 	Geom:        regexp.MustCompile(".g[0-9][0-9]"),     // `^\.g(0[1-9]|[1-9][0-9])$`
 	Plan:        regexp.MustCompile(".p[0-9][0-9]"),     // `^\.p(0[1-9]|[1-9][0-9])$`
 	Steady:      regexp.MustCompile(".f[0-9][0-9]"),     // `^\.f(0[1-9]|[1-9][0-9])$`
@@ -329,19 +329,19 @@ func NewRasModel(key string, fs filestore.FileStore) (*RasModel, error) {
 
 		switch {
 
-		case rasRE.Plan.MatchString(ext):
+		case RasRE.Plan.MatchString(ext):
 			rasWG.Plan.Add(1)
 			go getPlanData(&rm, fp, &rasWG.Plan)
 
-		case rasRE.Geom.MatchString(ext):
+		case RasRE.Geom.MatchString(ext):
 			rasWG.Geom.Add(1)
 			go getGeomData(&rm, fp, &rasWG.Geom)
 
-		case rasRE.AllFlow.MatchString(ext):
+		case RasRE.AllFlow.MatchString(ext):
 			rasWG.Flow.Add(1)
 			go getFlowData(&rm, fp, &rasWG.Flow)
 
-		case rm.Metadata.Projection == "" && rasRE.Projection.MatchString(ext):
+		case rm.Metadata.Projection == "" && RasRE.Projection.MatchString(ext):
 			if filepath.Base(key) != filepath.Base(fp) && fp != projecFile {
 				rasWG.Projection.Add(1)
 				go getProjection(&rm, fp, &rasWG.Projection)

--- a/tools/project.go
+++ b/tools/project.go
@@ -35,7 +35,7 @@ type PrjFileContents struct {
 	Description     string   //`json:"Description"`
 } //
 
-func readFirstLine(fs filestore.FileStore, fn string) (string, error) {
+func ReadFirstLine(fs filestore.FileStore, fn string) (string, error) {
 	file, err := fs.GetObject(fn)
 	if err != nil {
 		fmt.Println("Couldnt open the file", fn)
@@ -62,7 +62,7 @@ func verifyPrjPath(key string, rm *RasModel) error {
 		return errors.Errorf("%s is not a .prj file", key)
 	}
 
-	firstLine, err := readFirstLine(rm.FileStore, key)
+	firstLine, err := ReadFirstLine(rm.FileStore, key)
 	if err != nil {
 		return errors.Wrap(err, 0)
 	}


### PR DESCRIPTION
This PR makes it so that an entire RAS model does not need to be indexed when hitting the modelversion, isamodel, isgeospatial, and modeltype endpoints. This increases the speed of these endpoints tremendously.